### PR TITLE
prerequisites update

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To build your dApp, you'll need to install the dependencies, create a new projec
 ## Prerequisites
 
 - Node
+- Git (v2.38 or higher)
 
 ## How to use Celo Composer
 


### PR DESCRIPTION
This package's Prerequisites have been brought up to date.

Since Celo Composer uses the `sparse-checkout` command, if the user doesn't have the latest version of git, it will throw an error: 
```
error: failed to initialize sparse-checkout
```
I got this error, so I thought I should let other users who might get it know. I couldn't figure out at which version of git this error stopped happening, so I added version as 2.38 or higher. The most recent version of git is v2.38.

After doing some research, I think users won't get this error if they have version 2.26.3 or higher. As in this version, the `sparse-checkout` command had some changes [[ref](https://en.wikipedia.org/wiki/Git#cite_note-31)], but I couldn't double-check it.

**_Context_**

I am using Ubuntu 20.04 in WSL. If a user of Ubuntu 20.04 uses `apt-get` to update git, they will get version 2.25.1. By using the `git-core` PPA to update your git version, you will get the latest version, which is 2.38.