### PR TITLE
update hardhatconfig.js

### DIFF
--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -1,4 +1,4 @@
-require("@nomiclabs/hardhat-waffle");
+require("@nomicfoundation/hardhat-chai-matchers");
 require("dotenv").config({ path: ".env" });
 require("hardhat-deploy");
 const { task } = require("hardhat/config");


### PR DESCRIPTION
Seems like the @nomicfoundation/hardhat-chai-matchers plugin is now a drop-in replacement for the @nomiclabs/hardhat-waffle plugin. https://hardhat.org/hardhat-chai-matchers/docs/migrate-from-waffle. There are issues while compiling contracts. Replaced it. Please check. 