### PR TITLE
feat: Add "AI Agent" template option to project creation

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -37,6 +37,7 @@ export default class Create extends Command {
     "<%= config.bin %> <%= command.id %>",
     '<%= config.bin %> <%= command.id %> --name my-celo-app --owner "John Doe" --hardhat --template Minipay',
     '<%= config.bin %> <%= command.id %> -n my-app -o "Jane Smith" --no-hardhat',
+    '<%= config.bin %> <%= command.id %> --name my-ai-agent --owner "Developer" --template "AI Agent"',
   ];
 
   static override flags = {
@@ -58,7 +59,7 @@ export default class Create extends Command {
     template: Flags.string({
       char: "t",
       description: "Template to use for the project",
-      options: ["Minipay", "Valora"],
+      options: ["Minipay", "Valora", "AI Agent"],
       required: false,
     }),
   };
@@ -148,7 +149,7 @@ export default class Create extends Command {
 
       if (useTemplate) {
         const { templateName } = await inquirer.prompt({
-          choices: ["Minipay", "Valora"],
+          choices: ["Minipay", "Valora", "AI Agent"],
           default: "Minipay",
           message: "Which template do you want to use?",
           name: "templateName",

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -52,6 +52,10 @@ export const getTemplateUrl = (template: string) => {
       return "https://github.com/celo-org/valora-template.git";
     }
 
+    case "AI Agent": {
+      return "https://github.com/celo-org/simple-defi-ai-agent-template.git";
+    }
+
     default: {
       return "https://github.com/celo-org/minipay-template.git";
     }


### PR DESCRIPTION
- Updated create.ts to include a new template option for "AI Agent" in the command line interface.
- Modified the template selection to allow users to choose "AI Agent" alongside existing options "Minipay" and "Valora".
- Enhanced constant.ts to return the appropriate URL for the "AI Agent" template.