### PR TITLE
Fix navbar import mismatch for wallet connect components

### DIFF
--- a/templates/base/apps/web/src/components/navbar.tsx.hbs
+++ b/templates/base/apps/web/src/components/navbar.tsx.hbs
@@ -12,7 +12,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet"
 {{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb"))}}
-import { ConnectButton } from "@/components/connect-button"
+import { WalletConnectButton } from "@/components/connect-button"
 {{/if}}
 
 const navLinks = [
@@ -61,10 +61,10 @@ export function Navbar() {
                   {{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb"))}}
                     {{#if (eq templateType 'minipay')}}
                   <Button asChild className="w-full">
-                    <ConnectButton />
+                    <WalletConnectButton />
                   </Button>
                     {{else}}
-                  <ConnectButton />
+                  <WalletConnectButton />
                     {{/if}}
                   {{else}}
                   <Button className="w-full">Connect Wallet</Button>
@@ -104,7 +104,7 @@ export function Navbar() {
           
           <div className="flex items-center gap-3">
             {{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb"))}}
-            <ConnectButton />
+            <WalletConnectButton />
             {{else}}
             <Button variant="outline" size="sm">Connect Wallet</Button>
             {{/if}}


### PR DESCRIPTION
## Problem
When creating a new project with `npx @celo/celo-composer@latest create` and selecting a wallet provider (RainbowKit or Thirdweb), the generated navbar component had an import error. The navbar was trying to import `ConnectButton` from `@/components/connect-button`, but the actual components export `WalletConnectButton`.

## Solution
Updated the navbar template (`templates/base/apps/web/src/components/navbar.tsx.hbs`) to:
- Import `WalletConnectButton` instead of `ConnectButton`
- Update all usage instances in both mobile and desktop navigation

## Changes Made
- Fixed import statement on line 15
- Updated mobile menu usage (lines 64, 67) 
- Updated desktop navigation usage (line 107)

## Testing
This fix ensures that projects generated with wallet providers will have working navbar components without import errors.

## Impact
- ✅ Fixes build errors for new projects with wallet providers
- ✅ Maintains consistency with existing component naming
- ✅ No breaking changes to existing functionality
- ✅ Works for both RainbowKit and Thirdweb providers