### PR TITLE
fix(deps): bump next to 15.3.6 in templates/ai/chat-template (CVE-2025-55182)

### DIFF
--- a/templates/ai/chat-template/package.json
+++ b/templates/ai/chat-template/package.json
@@ -63,7 +63,7 @@
     "geist": "^1.3.1",
     "lucide-react": "^0.446.0",
     "nanoid": "^5.0.8",
-    "next": "15.3.0-canary.31",
+    "next": "15.3.6",
     "next-themes": "^0.3.0",
     "orderedmap": "^2.1.1",
     "papaparse": "^5.5.2",


### PR DESCRIPTION
## What

Bumps `next` from `15.3.0-canary.31` to `15.3.6` in `templates/ai/chat-template/package.json`.

## Why

The pinned canary version falls within the affected range of [GHSA-9qr9-h5gf-34mp](https://github.com/advisories/GHSA-9qr9-h5gf-34mp) (CVE-2025-55182), a critical RCE in the React flight protocol (CVSS 10.0, deserialization of untrusted data).

- Pinned version: `15.3.0-canary.31`
- Affected range matching this pin: `>= 15.3.0-canary.0, < 15.3.6`
- Patched version on the 15.3.x line: `15.3.6`

Because the version was pinned exactly, every user scaffolding from this template resolves to the vulnerable build until this pin is changed in-repo.

## Scope

This PR is intentionally scoped to `templates/ai/chat-template` only.

- `templates/base/apps/web` resolves to `next@14.2.35`, which is outside the affected range of this specific advisory (the 14.x range begins at `14.3.0-canary.77`).
- `templates/contracts/*` does not depend on Next.js.

Other Next.js advisories affecting `14.2.35` exist and can be addressed in a follow-up PR if desired.

## Verification

Before:

```
$ pnpm audit --prod --json | jq '.advisories[] | select(.github_advisory_id == "GHSA-9qr9-h5gf-34mp") | .severity'
"critical"
```

After bump (`next@15.3.6`): advisory no longer matches; `pnpm audit --prod` reports the patched advisory is resolved.

Local `pnpm install` in `templates/ai/chat-template` resolves cleanly with no peer-dep errors.

## Related

PR #352 (renovate, open since 2025-08-14) targets a path that no longer exists post-CLI-v2 refactor and bumps to `15.2.4` (still below the patched `15.2.6` for the 15.2.x line). It would not resolve this issue. Closing or rebasing that PR is at maintainer discretion.
