### PR TITLE
feat: add stablecoin gas abstraction helper and transaction demo for Farcaster miniapps

### DIFF
--- a/docs/templates/farcaster-miniapp.mdx
+++ b/docs/templates/farcaster-miniapp.mdx
@@ -35,3 +35,29 @@ To make your Miniapp discoverable, you must sign a manifest with your Farcaster 
   `https://farcaster.xyz/~/developers/mini-apps/manifest?domain=YOUR_DOMAIN` to
   sign the manifest.
 </Info>
+
+## Celo Gas Abstraction (Fee Currency)
+
+Celo's unique native gas abstraction allows users of your Farcaster Miniapp to pay gas fees in stablecoins (`cUSD`, `cEUR`, `cREAL`, `USDT`) instead of native `CELO` tokens.
+
+The template contains a predefined helper file:
+- **`apps/web/src/lib/celo-gas.ts`**: Contains fee currency contract mappings for Celo Mainnet and Celo Sepolia testnet, along with the `getFeeCurrencyAddress` function.
+
+To execute a transaction with stablecoin gas, pass the `feeCurrency` option in Wagmi's `sendTransaction` or `writeContract` functions:
+
+```typescript
+import { getFeeCurrencyAddress } from "@/lib/celo-gas";
+import { useChainId, useSendTransaction } from "wagmi";
+
+const chainId = useChainId();
+const { sendTransaction } = useSendTransaction();
+
+const feeCurrencyAddress = getFeeCurrencyAddress("cUSD", chainId);
+
+sendTransaction({
+  to: "0x...",
+  value: parseEther("1"),
+  // Pass the feeCurrency address here
+  ...(feeCurrencyAddress ? { feeCurrency: feeCurrencyAddress } : {}),
+});
+```

--- a/templates/base/apps/web/src/app/page.tsx.hbs
+++ b/templates/base/apps/web/src/app/page.tsx.hbs
@@ -2,7 +2,9 @@
 import { useMiniApp } from "@/contexts/miniapp-context";
 import { sdk } from "@farcaster/frame-sdk";
 import { useState, useEffect } from "react";
-import { useAccount, useConnect } from "wagmi";
+import { useAccount, useConnect, useSendTransaction, useChainId } from "wagmi";
+import { parseEther } from "viem";
+import { getFeeCurrencyAddress, StableGasToken } from "../lib/celo-gas";
 {{else}}
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -44,6 +46,35 @@ export default function Home() {
   const formatAddress = (address: string) => {
     if (!address || address.length < 10) return address;
     return `${address.slice(0, 6)}...${address.slice(-4)}`;
+  };
+
+  // Gas Abstraction states and hooks
+  const chainId = useChainId();
+  const [gasToken, setGasToken] = useState<StableGasToken | "CELO">("CELO");
+  const [txHash, setTxHash] = useState<string | null>(null);
+  const [txSuccess, setTxSuccess] = useState(false);
+  
+  const { sendTransactionAsync, isPending: isSendingTx, error: txError } = useSendTransaction();
+
+  const handleSendTestTx = async () => {
+    setTxHash(null);
+    setTxSuccess(false);
+    
+    try {
+      const feeCurrency = getFeeCurrencyAddress(gasToken, chainId);
+      const tx = await sendTransactionAsync({
+        to: (address || walletAddress) as `0x${string}`,
+        value: parseEther("0"),
+        ...(feeCurrency ? { feeCurrency } : {}),
+      });
+      
+      if (tx) {
+        setTxHash(tx);
+        setTxSuccess(true);
+      }
+    } catch (err) {
+      console.error("Failed to send transaction:", err);
+    }
   };
   
   if (!isMiniAppReady) {
@@ -168,6 +199,64 @@ export default function Home() {
             {addMiniAppMessage && (
               <div className="mt-3 p-3 bg-white/30 backdrop-blur-sm rounded-lg">
                 <p className="text-sm text-gray-700">{addMiniAppMessage}</p>
+              </div>
+            )}
+          </div>
+
+          {/* Celo Gas Abstraction Demo Card */}
+          <div className="mb-6 bg-white/20 backdrop-blur-sm px-6 py-6 rounded-lg text-left">
+            <h3 className="text-lg font-bold text-gray-900 mb-2">Celo Gas Abstraction</h3>
+            <p className="text-sm text-gray-600 mb-4">
+              On Celo, users can pay gas fees using stablecoins. Try sending a test transaction using a custom gas currency!
+            </p>
+            
+            {/* Currency Selector */}
+            <div className="mb-4">
+              <label className="block text-xs font-semibold text-gray-600 uppercase mb-2">
+                Pay Gas With:
+              </label>
+              <select
+                value={gasToken}
+                onChange={(e) => setGasToken(e.target.value as StableGasToken | "CELO")}
+                className="w-full bg-white text-gray-900 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 font-medium"
+              >
+                <option value="CELO">CELO (Native)</option>
+                <option value="cUSD">cUSD (Stablecoin)</option>
+                <option value="cEUR">cEUR (Stablecoin)</option>
+                <option value="cREAL">cREAL (Stablecoin)</option>
+                <option value="USDT">USDT (Stablecoin)</option>
+              </select>
+            </div>
+
+            <button
+              onClick={handleSendTestTx}
+              disabled={!isConnected || isSendingTx}
+              className="w-full bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white font-medium py-3 px-4 rounded-lg transition-colors duration-200 flex items-center justify-center gap-2"
+            >
+              {isSendingTx ? (
+                <>
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                  Sending Transaction...
+                </>
+              ) : (
+                <>
+                  <span>⚡</span>
+                  Send Test Tx
+                </>
+              )}
+            </button>
+
+            {/* Status Messages */}
+            {txSuccess && (
+              <div className="mt-3 p-3 bg-green-50 text-green-700 rounded-lg text-xs break-all border border-green-200">
+                <p className="font-semibold">Transaction Sent!</p>
+                <p className="mt-1 font-mono">{txHash}</p>
+              </div>
+            )}
+            {txError && (
+              <div className="mt-3 p-3 bg-red-50 text-red-700 rounded-lg text-xs border border-red-200 font-medium">
+                <p className="font-semibold text-red-800">Transaction Failed</p>
+                <p className="mt-1">{txError.message || "Unknown error occurred"}</p>
               </div>
             )}
           </div>

--- a/templates/farcaster-miniapp/FARCASTER_SETUP.md.hbs
+++ b/templates/farcaster-miniapp/FARCASTER_SETUP.md.hbs
@@ -99,6 +99,42 @@ The Farcaster manifest requires a signed account association to verify domain ow
 - The signed domain must exactly match where your app is hosted, including subdomains
 - If using ngrok, make sure the ngrok URL matches the signed domain
 
+## Celo Stablecoin Gas Fees (Gas Abstraction)
+
+One of Celo's most powerful features is **gas abstraction**, which allows users to pay for transaction gas fees using stablecoins (such as `cUSD`, `cEUR`, `cREAL`, or `USDT`) instead of the native `CELO` token. This is extremely beneficial for Frame/Miniapp users who may not hold native CELO.
+
+### How to Use Alternate Gas Currencies
+
+In Wagmi/Viem, you can configure gas abstraction by specifying the `feeCurrency` parameter on the transaction object.
+
+1. **Import the gas helper**:
+   We've included a helper at `@/lib/celo-gas` which lists the contract addresses for Celo gas currencies on both Mainnet and Sepolia.
+
+   ```typescript
+   import { getFeeCurrencyAddress } from "@/lib/celo-gas";
+   import { useChainId, useSendTransaction } from "wagmi";
+   ```
+
+2. **Send Transaction with feeCurrency**:
+   Pass the fee currency address to `sendTransaction` or `writeContract`:
+
+   ```typescript
+   const chainId = useChainId();
+   const { sendTransaction } = useSendTransaction();
+
+   const handleSend = () => {
+     // Retrieve stablecoin address (e.g. cUSD)
+     const feeCurrency = getFeeCurrencyAddress("cUSD", chainId);
+
+     sendTransaction({
+       to: "0x...",
+       value: parseEther("0.1"),
+       // Pass feeCurrency here
+       ...(feeCurrency ? { feeCurrency } : {}),
+     });
+   };
+   ```
+
 ## Additional Resources
 
 - [Farcaster Mini Apps Documentation](https://miniapps.farcaster.xyz/)

--- a/templates/farcaster-miniapp/apps/web/src/lib/celo-gas.ts.hbs
+++ b/templates/farcaster-miniapp/apps/web/src/lib/celo-gas.ts.hbs
@@ -1,0 +1,34 @@
+import { celo, celoSepolia } from "wagmi/chains";
+
+export const CELO_FEE_CURRENCIES = {
+  [celo.id]: {
+    cUSD: "0x765DE816845861e75A25fCA122bb6898B8B1282a" as const,
+    cEUR: "0xD8763C53112f612Fe77f1D1f0E821F9B3b354B4B" as const,
+    cREAL: "0xe8537a6d803a507257e6c0111532b7bc761e69b5" as const,
+    USDT: "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e" as const,
+  },
+  [celoSepolia.id]: {
+    cUSD: "0x874069Fa1Eb16D44d622F2e0Ca25eeA1700Ff7c2" as const,
+    cEUR: "0x10c8a1ae94747c6974ab159f8a1e2f7b8c2ecfb4" as const,
+    cREAL: "0xE4D517785D091D3c54818832dB6094bcc2744545" as const,
+    USDT: "0xe28cefdfdf275eec615367d603a442d5f9ef6a08" as const,
+  },
+};
+
+export type StableGasToken = "cUSD" | "cEUR" | "cREAL" | "USDT";
+
+/**
+ * Gets the contract address for the specified fee currency token on a given chain.
+ * Returns undefined for native CELO.
+ */
+export function getFeeCurrencyAddress(
+  token: StableGasToken | "CELO",
+  chainId: number
+): `0x${string}` | undefined {
+  if (token === "CELO") return undefined;
+
+  const chainCurrencies = CELO_FEE_CURRENCIES[chainId as keyof typeof CELO_FEE_CURRENCIES];
+  if (!chainCurrencies) return undefined;
+
+  return chainCurrencies[token as StableGasToken];
+}


### PR DESCRIPTION
This PR adds support for Celo's native gas abstraction feature in the Farcaster Miniapp (Frame v2) template. It includes a custom stablecoin gas helper (@/lib/celo-gas) that maps mainnet/Sepolia fee currency addresses (cUSD, cEUR, cREAL, USDT) and an interactive transaction demo card in page.tsx where developers can test sending transactions using their preferred fee currency. It also adds documentation to FARCASTER_SETUP.md and farcaster-miniapp.mdx.