### PR TITLE
docs: fix typos, broken links, and outdated references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Monorepo**: Turborepo-based monorepo structure
 - **Developer Experience**: Interactive CLI with progress indicators
 - **Template System**: Modular template composition
-- **Network Support**: Pre-configured for Celo mainnet and Alfajores testnet
+- **Network Support**: Pre-configured for Celo mainnet and Celo Sepolia testnet
 
 ### Technical Details
 - Node.js 18+ support

--- a/docs/development/deployment.mdx
+++ b/docs/development/deployment.mdx
@@ -47,7 +47,7 @@ While the specific steps may vary depending on the platform you choose, the gene
 
 ## Deploying Smart Contracts
 
-Your smart contracts need to be deployed to a public network (like Celo Sepolia Testnet testnet or Celo Mainnet) before your frontend application can interact with them.
+Your smart contracts need to be deployed to a public network (like Celo Sepolia Testnet or Celo Mainnet) before your frontend application can interact with them.
 
 - Use the `pnpm contracts:deploy:celo-sepolia` or `pnpm contracts:deploy:celo` scripts to deploy your contracts.
 - After deployment, you will get the contract addresses. You need to update your frontend's environment variables with these new addresses so it knows where to find the contracts on-chain.

--- a/docs/integrations/contracts/foundry.mdx
+++ b/docs/integrations/contracts/foundry.mdx
@@ -27,7 +27,7 @@ The template comes with the following features and configurations out of the box
 - **Sample Contract**: A simple `Counter.sol` contract to get you started.
 - **Deployment Scripts**: A `Counter.s.sol` script for deploying your contract using `forge script`.
 - **Tests**: A `Counter.t.sol` test file with examples of how to write tests for your contract using `forge test`.
-- **`.env.example`**: A template for your environment variables, including `PRIVATE_KEY` and `ETHERSCAN_API_KEY`.
+- **`.env.example`**: A template for your environment variables, including `PRIVATE_KEY` and `CELOSCAN_API_KEY`.
 
 ## Key Commands
 
@@ -51,7 +51,11 @@ To deploy to a specific network, you'll need to have your `PRIVATE_KEY` set in a
 
 ```bash
 # Deploy to Celo Sepolia
-forge script script/Counter.s.sol:CounterScript --rpc-url --chain-id --broadcast --verify
+forge script script/Counter.s.sol:CounterScript \
+  --rpc-url https://alfajores-forno.celo-testnet.org \
+  --chain-id 44787 \
+  --broadcast \
+  --verify
 
 # Deploy to Celo Mainnet
 forge script script/Counter.s.sol:CounterScript --rpc-url mainnet --broadcast --verify

--- a/docs/integrations/contracts/hardhat.mdx
+++ b/docs/integrations/contracts/hardhat.mdx
@@ -27,7 +27,7 @@ To deploy and verify your smart contracts, you'll need to set up your environmen
     This is highly sensitive and should be handled with extreme care. Do not
     commit this to version control.
   </Warning>
-- **`ETHERSCAN_API_KEY`**: (Optional) Your API key from [Etherscan](https://etherscan.io/) for automatically verifying your deployed contracts.
+- **`CELOSCAN_API_KEY`**: (Optional) Your API key from [Celoscan](https://etherscan.io/) for automatically verifying your deployed contracts.
 - **`REPORT_GAS`**: (Optional) Set to `true` to enable the gas reporter, which provides a detailed breakdown of gas usage for your contract's functions during testing.
 
 ## Monorepo Scripts


### PR DESCRIPTION
Hi team,

I've been going through the documentation and noticed a few small areas that could use some cleanup. I’ve put together this PR to address the following:

- **Fixed typos and formatting:** Corrected duplicate words and restructured the Changelog intro.
- **Foundry fix:** Fixed a broken deployment command that was missing necessary flags.
- **Updated API references:** Updated Etherscan references to Celoscan where appropriate.
- **Content updates:** Updated the Changelog to reflect the transition to Celo Sepolia testnet.

Everything should be straightforward, but please let me know if you'd like any adjustments. Happy to tweak anything!