### PR TITLE
fix(templates): ship an ESLint config so `next lint` can run

### DIFF
--- a/src/plopfile.ts
+++ b/src/plopfile.ts
@@ -214,6 +214,9 @@ export default function (plop: NodePlopAPI): void {
         globOptions: {
           dot: true,
         },
+        // The base template now ships an .eslintrc.json of its own, so this has to
+        // overwrite it rather than silently lose the Farcaster rule overrides.
+        force: true,
         skip: (data: PlopData): string | false => {
           if (data.templateType !== "farcaster-miniapp") {
             return "Skipping Farcaster Miniapp config - different template type selected";

--- a/templates/base/apps/web/.eslintrc.json.hbs
+++ b/templates/base/apps/web/.eslintrc.json.hbs
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}


### PR DESCRIPTION

`apps/web` has a `lint` script but no ESLint config, so `next lint`
falls through to its interactive setup wizard:

  ? How would you like to configure ESLint?
    Strict (recommended) / Base / Cancel

There is no TTY under `turbo lint` or in CI, so it cannot be answered
and the task exits 1. Every generated project fails `pnpm lint` at the
root, on every template that has an `apps/web`.

The repo already had the answer for exactly one template:
`templates/farcaster-miniapp` ships its own `.eslintrc.json` and is the
only one whose lint runs. This moves the same config into the base
template, where `eslint-config-next` is already a devDependency.

The Farcaster action now sets `force: true`. Without it the base file
lands first and Farcaster silently loses its three rule overrides —
caught by generating every template rather than only `basic`. Same
idiom the Minipay tailwind config already uses.

Verified per template after generating each one:

  basic              extends next/core-web-vitals, 0 rule overrides
  minipay            extends next/core-web-vitals, 0 rule overrides
  farcaster-miniapp  extends next/core-web-vitals, 3 rule overrides
  ai-chat            unaffected — standalone template, no apps/web

Scope note: this makes `next lint` *run*. It does not make it pass.
Once the wizard is out of the way it reports two real errors in
`navbar.tsx`, which are a separate bug with a separate cause — the
navbar imports `ConnectButton` while the component exports
`WalletConnectButton`. That is independently reproducible with
`tsc --noEmit` and has nothing to do with ESLint, so it is not fixed
here. Filed separately.



🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #395.
