### PR TITLE
fix(templates): navbar references a component that is never defined

### DIFF
--- a/templates/base/apps/web/src/components/navbar.tsx.hbs
+++ b/templates/base/apps/web/src/components/navbar.tsx.hbs
@@ -12,7 +12,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet"
 {{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb"))}}
-import { ConnectButton } from "@/components/connect-button"
+import { WalletConnectButton } from "@/components/connect-button"
 {{/if}}
 
 const navLinks = [

--- a/templates/minipay/components/connect-button.tsx.hbs
+++ b/templates/minipay/components/connect-button.tsx.hbs
@@ -4,7 +4,7 @@
 import { ConnectButton as RainbowKitConnectButton } from "@rainbow-me/rainbowkit";
 import { useEffect, useState } from "react";
 
-export function ConnectButton() {
+export function WalletConnectButton() {
   const [isMinipay, setIsMinipay] = useState(false);
 
   useEffect(() => {

--- a/templates/minipay/components/wallet-provider.tsx.hbs
+++ b/templates/minipay/components/wallet-provider.tsx.hbs
@@ -9,7 +9,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { WagmiProvider, createConfig, http, useConnect } from "wagmi";
 import { celo, celoSepolia } from "wagmi/chains";
-import { ConnectButton } from "./connect-button";
 
 const connectors = connectorsForWallets(
   [


### PR DESCRIPTION

`apps/web/src/components/navbar.tsx` imports `ConnectButton` and then
renders `<WalletConnectButton />` three times. The two names are not the
same symbol, so the generated app has an unused import and an undefined
component.

`tsc --noEmit` on a default `create demo -t basic` from main:

  navbar.tsx(14,10): error TS2459: Module '"@/components/connect-button"'
    declares 'ConnectButton' locally, but it is not exported.
  navbar.tsx(59,20): error TS2552: Cannot find name 'WalletConnectButton'.
  navbar.tsx(94,14): error TS2552: Cannot find name 'WalletConnectButton'.

So `turbo type-check` is red on the default scaffold, for every wallet
provider.

The underlying cause is a naming inconsistency rather than a typo.
Three of the four connect-button components export
`WalletConnectButton` — rainbowkit, thirdweb, farcaster-miniapp — and
only Minipay exports `ConnectButton`. The navbar was written against
the odd one out while rendering the majority name.

This normalises Minipay onto `WalletConnectButton` and points the
navbar import at it. The three render sites are already correct and are
untouched. Minipay's `wallet-provider.tsx` imported the old name and
never used it, so that import is dropped rather than renamed to
something equally unused.

Verified by generating each combination and type-checking:

  basic + rainbowkit    import matches export, tsc clean
  basic + thirdweb      import matches export, tsc clean
  minipay               import matches export, tsc clean

Unrelated and not addressed here: `next build` on the same scaffold
fails separately with an unmet `@x402/evm` peer reached through
wagmi -> rainbowkit. That reproduces on main without this change.



Closes #396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
