### PR TITLE
fix(templates): quote the hyphenated network keys in hardhat.config

### DIFF
--- a/templates/contracts/hardhat/hardhat.config.ts.hbs
+++ b/templates/contracts/hardhat/hardhat.config.ts.hbs
@@ -19,7 +19,7 @@ const config: HardhatUserConfig = {
       chainId: 42220,
     },
     // Celo Sepolia Testnet
-    celo-sepolia: {
+    "celo-sepolia": {
       url: "https://forno.celo-sepolia.celo-testnet.org/",
       accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
       chainId: 11142220,
@@ -33,7 +33,7 @@ const config: HardhatUserConfig = {
   etherscan: {
     apiKey: {
       celo: process.env.ETHERSCAN_API_KEY || "",
-      celo-sepolia: process.env.ETHERSCAN_API_KEY || "",
+      "celo-sepolia": process.env.ETHERSCAN_API_KEY || "",
     },
     customChains: [
       {


### PR DESCRIPTION
Closes #399.

## The bug

`celo-sepolia` is used as a bare object key in two places in `templates/contracts/hardhat/hardhat.config.ts.hbs`. A hyphen is not valid in an unquoted identifier, so the generated `hardhat.config.ts` is not parseable TypeScript and **every** Hardhat task fails — on the default scaffold, since Hardhat is the default for both `basic` and `minipay`.

## Why quoting, and not renaming to `celoSepolia`

The key is not just a key — it is the **Hardhat network name**. The same template ships:

```json
"deploy:celo-sepolia": "hardhat ignition deploy ignition/modules/Lock.ts --network celo-sepolia"
```

and `README.md.hbs` documents `pnpm deploy:celo-sepolia`, the RPC and the faucet under that name. Renaming the key would fix the compile error and break the deploy script instead. Quoting keeps the string identical, so nothing downstream moves.

## Verified on a generated project, both directions

Built the CLI from this branch and scaffolded `create demo -y` (basic + rainbowkit + hardhat).

**Before** — reverting just those two lines in the generated file reproduces exactly what the issue reports:

```
apps/contracts/hardhat.config.ts(22,9):  error TS1005: ',' expected.
apps/contracts/hardhat.config.ts(23,12): error TS1003: Identifier expected.
apps/contracts/hardhat.config.ts(23,58): error TS1005: ':' expected.
apps/contracts/hardhat.config.ts(24,24): error TS1005: ',' expected.
```

**After** — `tsc --noEmit` on the generated config exits 0.

## Scope

Two lines. I also swept every `*.ts.hbs` / `*.tsx.hbs` template for the same shape (an unquoted hyphenated object key) and this was the only occurrence, so there is no sibling of this bug left to file.