### PR TITLE
fix(templates): make Foundry projects actually build

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -343,43 +343,93 @@ export async function createCommand(
       });
 
       // If Foundry is the selected contract framework, install its dependencies
+      let foundryInstallFailed = false;
       if (finalContractFramework === "foundry") {
         const contractsPath = path.join(projectPath, "apps", "contracts");
         spinner.start("Installing Foundry dependencies...");
         try {
           await new Promise<void>((resolve, reject) => {
+            // No `--no-commit`. Forge removed that flag — not committing is the
+            // default now — and passing it makes the whole command fail with
+            // "unexpected argument '--no-commit' found" on any current install.
             const installProcess = spawn(
               "forge",
-              ["install", "foundry-rs/forge-std", "--no-commit"],
+              ["install", "foundry-rs/forge-std"],
               { cwd: contractsPath, stdio: "pipe" }
             );
+
+            // Keep forge's own message. "exited with code 2" on its own tells
+            // the user nothing about what to do next.
+            let stderr = "";
+            installProcess.stderr?.on("data", (chunk) => {
+              stderr += String(chunk);
+            });
 
             installProcess.on("close", (code) => {
               if (code === 0) {
                 resolve();
               } else {
-                reject(new Error(`'forge install' failed with code ${code}`));
+                reject(
+                  new Error(
+                    stderr.trim() || `'forge install' exited with code ${code}`
+                  )
+                );
               }
             });
 
-            installProcess.on("error", (err) => {
-              reject(err);
+            installProcess.on("error", (err: NodeJS.ErrnoException) => {
+              reject(
+                new Error(
+                  err.code === "ENOENT"
+                    ? "'forge' is not on PATH. Install Foundry first: https://getfoundry.sh"
+                    : err.message
+                )
+              );
             });
           });
           spinner.succeed("Foundry dependencies installed successfully.");
         } catch (error) {
-          spinner.fail("Failed to install Foundry dependencies.");
-          console.error(error);
-          // We don't exit here, just warn the user.
+          // Loudly, and with the command that fixes it. A silent warning here
+          // produced a project that could not compile at all: script/Counter.s.sol
+          // and test/Counter.t.sol both import forge-std, so without lib/forge-std
+          // `forge build` fails on every file.
+          foundryInstallFailed = true;
+          spinner.fail("Could not install Foundry dependencies.");
+          console.error(
+            chalk.red(
+              `  ${error instanceof Error ? error.message : String(error)}`
+            )
+          );
+          console.log(
+            chalk.yellow(
+              "\n  The project was generated, but it will NOT compile until forge-std is\n" +
+                "  installed — both the script and the test import from it. Finish with:\n"
+            )
+          );
+          console.log(
+            chalk.white(
+              `    cd ${finalProjectName}/apps/contracts && forge install foundry-rs/forge-std\n`
+            )
+          );
         }
       }
 
-      console.log(chalk.green.bold("\n🎉 Your Celo project is ready!\n"));
+      console.log(
+        foundryInstallFailed
+          ? chalk.yellow.bold("\n⚠️  Your Celo project is generated, but incomplete.\n")
+          : chalk.green.bold("\n🎉 Your Celo project is ready!\n")
+      );
       console.log(chalk.cyan("Next steps:"));
       console.log(chalk.white(`  cd ${finalProjectName}`));
 
       if (!shouldInstall) {
         console.log(chalk.white("  pnpm install"));
+      }
+
+      if (foundryInstallFailed) {
+        console.log(
+          chalk.white("  cd apps/contracts && forge install foundry-rs/forge-std && cd ../..")
+        );
       }
 
       console.log(chalk.white("  pnpm dev"));

--- a/templates/base/package.json.hbs
+++ b/templates/base/package.json.hbs
@@ -13,7 +13,12 @@
     "contracts:test": "turbo run test --filter=hardhat",
     "contracts:deploy": "turbo run deploy --filter=hardhat",
     "contracts:deploy:celo-sepolia": "turbo run deploy:celo-sepolia --filter=hardhat",
-    "contracts:deploy:celo": "turbo run deploy:celo --filter=hardhat"{{/if}}
+    "contracts:deploy:celo": "turbo run deploy:celo --filter=hardhat"{{/if}}{{#if (eq contractFramework "foundry")}},
+    "contracts:compile": "turbo run compile --filter=foundry",
+    "contracts:test": "turbo run test --filter=foundry",
+    "contracts:deploy": "turbo run deploy --filter=foundry",
+    "contracts:deploy:celo-sepolia": "turbo run deploy:celo-sepolia --filter=foundry",
+    "contracts:deploy:celo": "turbo run deploy:celo --filter=foundry"{{/if}}
   },
   "devDependencies": {
     "@types/node": "^20.8.0",

--- a/templates/base/turbo.json.hbs
+++ b/templates/base/turbo.json.hbs
@@ -32,6 +32,25 @@
     },
     "deploy:celo": {
       "dependsOn": ["compile"]
+    }{{/if}}{{#if (eq contractFramework "foundry")}},
+    "compile": {
+      "dependsOn": ["^compile"],
+      "outputs": ["out/**", "cache/**"]
+    },
+    "test": {
+      "dependsOn": ["compile"]
+    },
+    "deploy": {
+      "dependsOn": ["compile"],
+      "cache": false
+    },
+    "deploy:celo-sepolia": {
+      "dependsOn": ["compile"],
+      "cache": false
+    },
+    "deploy:celo": {
+      "dependsOn": ["compile"],
+      "cache": false
     }{{/if}}
   }
 }

--- a/templates/contracts/foundry/.env.example.hbs
+++ b/templates/contracts/foundry/.env.example.hbs
@@ -1,0 +1,20 @@
+# The private key of the account to use for deployments.
+# IMPORTANT: DO NOT USE A KEY THAT HOLDS REAL FUNDS.
+# ⚠️  NEVER commit this file with real values to version control
+#
+# Foundry reads this through --private-key or via `forge script --account`.
+# The deploy scripts below expect PRIVATE_KEY in the environment:
+#   source .env && forge script script/Counter.s.sol:CounterScript \
+#     --rpc-url celo-sepolia --private-key $PRIVATE_KEY --broadcast
+
+PRIVATE_KEY=
+
+# (Optional) API key for contract verification on Etherscan V2.
+# Get yours from https://etherscan.io/
+ETHERSCAN_API_KEY=
+
+# RPC endpoints are already named in foundry.toml, so `--rpc-url celo-sepolia`
+# and `--rpc-url celo` work without setting anything here. Override only if you
+# want a different provider.
+# CELO_RPC_URL=https://forno.celo.org
+# CELO_SEPOLIA_RPC_URL=https://forno.celo-sepolia.celo-testnet.org/

--- a/templates/contracts/foundry/README.md.hbs
+++ b/templates/contracts/foundry/README.md.hbs
@@ -1,0 +1,66 @@
+# Smart Contracts — {{projectName}}
+
+Foundry project for the Celo network.
+
+## Setup
+
+Dependencies are installed by the scaffolder. If that step failed, or you cloned this
+project fresh, install them yourself from this directory:
+
+```bash
+forge install foundry-rs/forge-std
+```
+
+`lib/` is gitignored — Foundry tracks dependencies as git submodules, so a fresh clone
+needs `git submodule update --init --recursive` (or the `forge install` above).
+
+Copy the environment file and fill in a deployment key:
+
+```bash
+cp .env.example .env
+```
+
+## Commands
+
+Run these from the repository root, so turbo picks them up:
+
+```bash
+pnpm contracts:compile              # forge build
+pnpm contracts:test                 # forge test
+pnpm contracts:deploy:celo-sepolia  # deploy to Celo Sepolia
+pnpm contracts:deploy:celo          # deploy to Celo Mainnet
+```
+
+Or directly in this directory with `forge build`, `forge test`, `forge script ...`.
+
+## Networks
+
+`foundry.toml` already names both RPC endpoints, so `--rpc-url celo-sepolia` and
+`--rpc-url celo` work with no further configuration.
+
+| | Celo Sepolia (testnet) | Celo Mainnet |
+|---|---|---|
+| Chain ID | 11142220 | 42220 |
+| RPC | https://forno.celo-sepolia.celo-testnet.org/ | https://forno.celo.org |
+| Explorer | https://sepolia.celoscan.io | https://celoscan.io |
+| Faucet | https://faucet.celo.org/celo-sepolia | — |
+
+## Deploying
+
+The deploy scripts pass `--broadcast` and expect a key. The most direct form:
+
+```bash
+source .env
+forge script script/Counter.s.sol:CounterScript \
+  --rpc-url celo-sepolia \
+  --private-key $PRIVATE_KEY \
+  --broadcast
+```
+
+For anything holding real funds, prefer a keystore over a raw key in the environment:
+
+```bash
+cast wallet import deployer --interactive
+forge script script/Counter.s.sol:CounterScript \
+  --rpc-url celo --account deployer --broadcast
+```

--- a/templates/contracts/foundry/package.json.hbs
+++ b/templates/contracts/foundry/package.json.hbs
@@ -1,0 +1,24 @@
+{
+  "name": "foundry",
+  "version": "1.0.0",
+  "description": "Smart contracts for {{projectName}}",
+  "private": true,
+  "scripts": {
+    "build": "forge build",
+    "compile": "forge build",
+    "test": "forge test",
+    "deploy": "forge script script/Counter.s.sol:CounterScript --broadcast",
+    "deploy:celo-sepolia": "forge script script/Counter.s.sol:CounterScript --rpc-url celo-sepolia --broadcast",
+    "deploy:celo": "forge script script/Counter.s.sol:CounterScript --rpc-url celo --broadcast",
+    "clean": "forge clean"
+  },
+  "keywords": [
+    "foundry",
+    "ethereum",
+    "celo",
+    "smart-contracts",
+    "solidity"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/templates/contracts/foundry/remappings.txt.hbs
+++ b/templates/contracts/foundry/remappings.txt.hbs
@@ -1,0 +1,1 @@
+forge-std/=lib/forge-std/src/

--- a/templates/contracts/foundry/script/Counter.s.sol.hbs
+++ b/templates/contracts/foundry/script/Counter.s.sol.hbs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.28;
 
-import {Script, console} from "forge-std/Script.sol";
+import {Script} from "forge-std/Script.sol";
 import {Counter} from "../src/Counter.sol";
 
 contract CounterScript is Script {

--- a/templates/contracts/foundry/src/Counter.sol.hbs
+++ b/templates/contracts/foundry/src/Counter.sol.hbs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.28;
 
 contract Counter {
     uint256 public number;

--- a/templates/contracts/foundry/test/Counter.t.sol.hbs
+++ b/templates/contracts/foundry/test/Counter.t.sol.hbs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.28;
 
-import {Test, console} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {Counter} from "../src/Counter.sol";
 
 contract CounterTest is Test {


### PR DESCRIPTION
Closes #406.

## 1. `forge install` could never have worked

```ts
["install", "foundry-rs/forge-std", "--no-commit"]
```

Current forge rejects that outright:

```
error: unexpected argument '--no-commit' found
  tip: a similar argument exists: '--commit'
```

The flag was removed — not committing is the default now. And the failure was caught and downgraded to a console warning, so the CLI printed **"🎉 Your Celo project is ready!"** over a project with no `lib/forge-std`. Both `script/Counter.s.sol` and `test/Counter.t.sol` import from it, so nothing compiled at all.

Fixed by dropping the flag, keeping forge's own stderr rather than `'forge install' failed with code 2`, and handling `ENOENT` separately so "forge isn't installed" says so instead of surfacing a raw Node error.

**And it now fails loudly.** The summary changes to `⚠️  Your Celo project is generated, but incomplete.` and the next-steps block prints the exact recovery command. A warning nobody reads is how this shipped broken.

## 2. The template was a stub

`templates/contracts/foundry/` had only `foundry.toml`, the three `.sol` files and a `.gitignore`. Added:

| file | why |
|---|---|
| `package.json.hbs` | `apps/contracts` was not a workspace member at all, so no root script could reach it |
| `remappings.txt.hbs` | makes `forge-std/` explicit rather than relying on auto-detection |
| `.env.example.hbs` | `docs/integrations/contracts/foundry.mdx:30` already tells people to copy it (part of #419) |
| `README.md.hbs` | hardhat has one; this documents both networks, the submodule caveat and a keystore-based deploy |

## 3. No workspace integration

`templates/base/package.json.hbs` and `turbo.json.hbs` had `hardhat` branches and no `foundry` branch, so a Foundry project got zero `contracts:*` scripts and zero turbo tasks. Added both, mirroring hardhat. Turbo outputs are `out/**` and `cache/**` (forge's, not hardhat's), and the deploy tasks are `"cache": false` since broadcasting is not a cacheable operation.

## 4. Minor

Pragma `^0.8.13` → `^0.8.28`, matching the hardhat template. Also dropped the unused `console` imports from the script and test — a fresh scaffold was emitting two `note[unused-import]` lint notes from forge's own linter.

## Verified end to end

On a `create demo -t basic --wallet-provider none -c foundry` scaffold:

```
✔ Foundry dependencies installed successfully.

$ forge build
Compiling 23 files with Solc 0.8.30
Compiler run successful!          # no notes, no warnings

$ forge test
[PASS] testFuzz_SetNumber(uint256) (runs: 256, μ: 26646, ~: 29289)
[PASS] test_Increment() (gas: 28783)
2 passed; 0 failed

$ pnpm contracts:test              # from the repo root, through turbo
Tasks: 2 successful, 2 total
```

**Regression check on the two shared files:** a `-c hardhat` scaffold still gets exactly its five `contracts:*` scripts filtered to `hardhat` and the same turbo tasks; a `-c none` scaffold still gets no contracts scripts and only the base tasks. All three modes emit valid JSON.

## Not included

`.gitignore` keeps ignoring `lib/`, which is right for submodules — the pointer is tracked in `.gitmodules`. The README says so, since a fresh clone needs `git submodule update --init --recursive`.

Tested with forge 1.5.1-stable.