### PR TITLE
fix(templates): read the WalletConnect env var the env template defines

### DIFF
--- a/templates/minipay/components/wallet-provider.tsx.hbs
+++ b/templates/minipay/components/wallet-provider.tsx.hbs
@@ -20,7 +20,7 @@ const connectors = connectorsForWallets(
   ],
   {
     appName: "{{projectName}}",
-    projectId: process.env.NEXT_PUBLIC_WC_PROJECT_ID!,
+    projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || "YOUR_PROJECT_ID",
   }
 );
 


### PR DESCRIPTION
Closes #401.

`templates/minipay/components/wallet-provider.tsx.hbs` read `NEXT_PUBLIC_WC_PROJECT_ID`. That name exists nowhere else in the repo — `.env.template.hbs`, the rainbowkit template and `docs/integrations/wallets/rainbowkit.mdx` all use `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID`. So a MiniPay scaffold initialised WalletConnect with `undefined` no matter how correctly the user followed the instructions.

Also replaced the non-null assertion with the same `|| "YOUR_PROJECT_ID"` fallback the rainbowkit template uses. **The `!` is why this shipped**: it asserted to the type checker that the value was always there, so nothing flagged it, and inside MiniPay itself the injected-connector path works — which hides the breakage from exactly the person most likely to notice it.

Verified on a `create demo -t minipay -c none` scaffold — the component and the generated env template now name the same variable:

```
apps/web/.env.template:7                     NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_project_id_here
apps/web/src/components/wallet-provider.tsx:21  process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || "YOUR_PROJECT_ID"
```