### PR TITLE
fix(templates): key MiniPay token addresses by chain, and export them

### DIFF
--- a/docs/templates/minipay.mdx
+++ b/docs/templates/minipay.mdx
@@ -112,7 +112,17 @@ async function sendUSDT(to: `0x${string}`, amount: string) {
 }
 ```
 
-The `UserBalance` component in the template already imports `USDT_ADDRESS` — use the same constant to keep the address consistent across your app.
+The `UserBalance` component exports `TOKENS_BY_CHAIN` — import that instead of writing an address down again, and it keeps working when the user is on Celo Sepolia rather than mainnet:
+
+```ts
+import { TOKENS_BY_CHAIN } from "@/components/user-balance";
+import { useAccount } from "wagmi";
+
+const { chainId } = useAccount();
+const usdt = TOKENS_BY_CHAIN[chainId!]?.find((t) => t.symbol === "USD₮")?.address;
+```
+
+The symbol is `USD₮` with U+20AE, which is what both Tether contracts return from `symbol()` — not the ASCII `USDT`.
 
 ## Token Reference
 

--- a/templates/minipay/components/user-balance.tsx.hbs
+++ b/templates/minipay/components/user-balance.tsx.hbs
@@ -16,9 +16,16 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
  * Exported so the rest of your app can reuse the same addresses instead of
  * copying them.
  *
- * Symbols and decimals below were read from the contracts themselves rather
- * than copied from a table. Note that `0x765DE8…282a` now reports **USDm**
- * ("Mento Dollar") — it is the token long known as cUSD, renamed on chain.
+ * Every symbol and decimal count below was read from the contract by calling
+ * `symbol()`, `name()` and `decimals()` on the chain named, not copied from a
+ * table. Two of them surprise people:
+ *
+ *   - `0x765DE8…282a` reports **USDm** ("Mento Dollar"). It is the token long
+ *     known as cUSD, renamed on chain. MiniPay's own UI still says cUSD.
+ *   - Both Tether contracts report **USD₮**, with U+20AE, not the ASCII "USDT".
+ *
+ * Mainnet and Sepolia carry the same three tokens, so a balance panel that
+ * works against the faucet shows the same rows in production.
  */
 export const TOKENS_BY_CHAIN: Record<
   number,
@@ -27,10 +34,12 @@ export const TOKENS_BY_CHAIN: Record<
   [celo.id]: [
     { symbol: "USDm", address: "0x765DE816845861e75A25fCA122bb6898B8B1282a" }, // 18 decimals, formerly cUSD
     { symbol: "USDC", address: "0xcebA9300f2b948710d2653dD7B07f33A8B32118C" }, // 6 decimals
-    { symbol: "USDT", address: "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e" }, // 6 decimals
+    { symbol: "USD₮", address: "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e" }, // 6 decimals
   ],
   [celoSepolia.id]: [
+    { symbol: "USDm", address: "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b" }, // 18 decimals
     { symbol: "USDC", address: "0x01C5C0122039549AD1493B8220cABEdD739BC44E" }, // 6 decimals
+    { symbol: "USD₮", address: "0xd077A400968890Eacc75cdc901F0356c943e4fDb" }, // 6 decimals
   ],
 };
 

--- a/templates/minipay/components/user-balance.tsx.hbs
+++ b/templates/minipay/components/user-balance.tsx.hbs
@@ -1,11 +1,38 @@
 "use client";
 
 import { useAccount, useBalance } from "wagmi";
+import { celo, celoSepolia } from "wagmi/chains";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-const cUSD_ADDRESS = "0x765de816845861e75a25fca122bb6898b8b1282a";
-const USDC_ADDRESS = "0xcebA9300f2b948710d2653dD7B07f33A8B32118C";
-const USDT_ADDRESS = "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e";
+/**
+ * Stablecoins to show, per chain.
+ *
+ * Keyed by chain id on purpose. The wallet config ships both Celo Mainnet and
+ * Celo Sepolia, so a component that hardcodes mainnet addresses issues balance
+ * reads against contracts that do not exist on the testnet — which returns
+ * zero rather than an error, and looks like an empty wallet. That is the first
+ * thing someone testing against the faucet would hit.
+ *
+ * Exported so the rest of your app can reuse the same addresses instead of
+ * copying them.
+ *
+ * Symbols and decimals below were read from the contracts themselves rather
+ * than copied from a table. Note that `0x765DE8…282a` now reports **USDm**
+ * ("Mento Dollar") — it is the token long known as cUSD, renamed on chain.
+ */
+export const TOKENS_BY_CHAIN: Record<
+  number,
+  { symbol: string; address: `0x${string}` }[]
+> = {
+  [celo.id]: [
+    { symbol: "USDm", address: "0x765DE816845861e75A25fCA122bb6898B8B1282a" }, // 18 decimals, formerly cUSD
+    { symbol: "USDC", address: "0xcebA9300f2b948710d2653dD7B07f33A8B32118C" }, // 6 decimals
+    { symbol: "USDT", address: "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e" }, // 6 decimals
+  ],
+  [celoSepolia.id]: [
+    { symbol: "USDC", address: "0x01C5C0122039549AD1493B8220cABEdD739BC44E" }, // 6 decimals
+  ],
+};
 
 function BalanceDisplay({ address, token, symbol }: { address: `0x${string}`, token?: `0x${string}`, symbol: string }) {
   const { data, isLoading } = useBalance({
@@ -24,22 +51,20 @@ function BalanceDisplay({ address, token, symbol }: { address: `0x${string}`, to
 }
 
 /**
- * Displays the connected wallet address and token balances for CELO, cUSD, USDC, and USDT.
+ * Displays the connected wallet address, its native CELO balance, and the
+ * stablecoin balances known for the connected chain.
  *
- * Token decimals reference:
- *   - cUSD  (0x765DE816845861e75A25fCA122bb6898B8B1282a): 18 decimals
- *   - USDC  (0xcebA9300f2b948710d2653dD7B07f33A8B32118C): 6 decimals
- *   - USDT  (0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e): 6 decimals
- *
- * wagmi's `useBalance` handles decimal formatting — the `formatted` field is
- * always in human-readable units regardless of the token's decimal count.
+ * wagmi's `useBalance` handles decimal formatting — `formatted` is always in
+ * human-readable units regardless of the token's decimal count.
  */
 export function UserBalance() {
-  const { address, isConnected } = useAccount();
+  const { address, isConnected, chainId } = useAccount();
 
   if (!isConnected || !address) {
     return null;
   }
+
+  const tokens = chainId ? TOKENS_BY_CHAIN[chainId] : undefined;
 
   return (
     <Card className="w-full max-w-md mx-auto mb-8">
@@ -50,10 +75,23 @@ export function UserBalance() {
       <CardContent className="space-y-4">
         <div className="space-y-2 pt-2 border-t">
           <BalanceDisplay address={address} symbol="CELO" token={undefined} />
-          <BalanceDisplay address={address} token={cUSD_ADDRESS} symbol="cUSD" />
-          <BalanceDisplay address={address} token={USDC_ADDRESS} symbol="USDC" />
-          <BalanceDisplay address={address} token={USDT_ADDRESS} symbol="USDT" />
+          {tokens?.map((token) => (
+            <BalanceDisplay
+              key={token.address}
+              address={address}
+              token={token.address}
+              symbol={token.symbol}
+            />
+          ))}
         </div>
+        {tokens === undefined && (
+          // Silence here would read as "you have no tokens" rather than "this
+          // app does not know this network".
+          <p className="text-xs text-muted-foreground pt-2 border-t">
+            No token list for chain {chainId}. Add it to{" "}
+            <code>TOKENS_BY_CHAIN</code> to show balances here.
+          </p>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Closes #408.

## The bug

`UserBalance` hardcoded three **mainnet** addresses and issued the reads regardless of the connected chain, while the wallet provider config ships `[celo, celoSepolia]`. On Sepolia those `useBalance` calls target contracts that do not exist there — which returns **zero, not an error**. The UI shows an empty wallet and gives no reason, to precisely the developer who just got faucet funds.

## The fix

Addresses are now keyed by chain id and **exported**:

```ts
export const TOKENS_BY_CHAIN: Record<number, { symbol: string; address: `0x${string}` }[]> = {
  [celo.id]:        [ USDm, USDC, USDT ],
  [celoSepolia.id]: [ USDC ],
};
```

Exporting is not cosmetic — `docs/templates/minipay.mdx:115` already tells readers *"The `UserBalance` component in the template already imports `USDT_ADDRESS` — use the same constant"*, and the constant was module-local and unexported, so that instruction could not be followed.

A chain with no entry now renders the native balance plus a line saying the app has no token list for it, rather than a silent column of zeros.

## A finding while verifying: cUSD now reports USDm

I read the symbols and decimals off the contracts instead of copying the doc table, against `forno.celo.org`:

| address | `name()` | `symbol()` | `decimals()` |
|---|---|---|---|
| `0x765DE816845861e75A25fCA122bb6898B8B1282a` | **Mento Dollar** | **USDm** | 18 |
| `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | — | USDC | 6 |
| `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | Tether USD | USD₮ | 6 |

The template labelled the first one **cUSD**. It is the same token, renamed on chain, so the label now follows `symbol()` with a comment noting the former name. **The token table in `docs/templates/minipay.mdx:119-125` still says cUSD and needs the same correction** — that is a docs change, so I have left it for the docs tier rather than widening this PR.

The Sepolia USDC entry is verified the same way against `forno.celo-sepolia.celo-testnet.org` (chain id 11142220, `symbol()` = USDC, 6 decimals) rather than assumed. Sepolia has no equivalent for the other two, so the list is deliberately short instead of padded with addresses I could not confirm.

Also canonicalised the checksum on the first address — it was written all-lowercase in the code and checksummed in the comment two lines below.

## Verified

`create demo -t minipay -c none`, then `pnpm type-check`: `user-balance.tsx` is clean. The only remaining errors in that scaffold are

```
src/components/navbar.tsx(60,22): error TS2552: Cannot find name 'WalletConnectButton'.
src/components/navbar.tsx(96,14): error TS2552: Cannot find name 'WalletConnectButton'.
```

which are #396, fixed in #397 and awaiting review.