### PR TITLE
fix(templates): drop TypeChain from the hardhat template, which is viem-first

### DIFF
--- a/docs/integrations/contracts/hardhat.mdx
+++ b/docs/integrations/contracts/hardhat.mdx
@@ -16,7 +16,7 @@ This application comes with:
 - **Sample Contract**: A simple `Lock.sol` contract to get you started.
 - **Comprehensive Tests**: A full test suite for the sample contract using Viem and Hardhat's testing utilities.
 - **Deployment Scripts**: A deployment module using Hardhat Ignition, the modern way to deploy your contracts.
-- **TypeChain Support**: Automatically generated TypeScript bindings for your contracts, providing type safety when you interact with them from your frontend.
+- **Type-safe contract calls**: The Viem toolbox infers types from your compiled artifacts, so contract reads and writes are typed without a separate binding-generation step.
 
 ## Environment Variables
 

--- a/templates/base/turbo.json.hbs
+++ b/templates/base/turbo.json.hbs
@@ -19,7 +19,7 @@
     }{{#if (eq contractFramework "hardhat")}},
     "compile": {
       "dependsOn": ["^compile"],
-      "outputs": ["artifacts/**", "cache/**", "typechain-types/**"]
+      "outputs": ["artifacts/**", "cache/**"]
     },
     "test": {
       "dependsOn": ["compile"]

--- a/templates/contracts/hardhat/package.json.hbs
+++ b/templates/contracts/hardhat/package.json.hbs
@@ -11,8 +11,7 @@
     "deploy:celo-sepolia": "hardhat ignition deploy ignition/modules/Lock.ts --network celo-sepolia",
     "deploy:celo": "hardhat ignition deploy ignition/modules/Lock.ts --network celo",
     "verify": "hardhat verify",
-    "clean": "hardhat clean",
-    "typechain": "hardhat typechain"
+    "clean": "hardhat clean"
   },
   "keywords": [
     "hardhat",
@@ -29,11 +28,8 @@
     "@nomicfoundation/hardhat-ignition": "^0.15.0",
     "@nomicfoundation/hardhat-ignition-ethers": "^0.15.0",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
-    "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "@nomicfoundation/hardhat-toolbox-viem": "^3.0.0",
     "@nomicfoundation/hardhat-verify": "^2.0.0",
-    "@typechain/ethers-v6": "^0.5.0",
-    "@typechain/hardhat": "^9.0.0",
     "@types/chai": "^4.2.0",
     "@types/mocha": ">=9.1.0",
     "chai": "^4.2.0",
@@ -42,7 +38,6 @@
     "hardhat-gas-reporter": "^1.0.8",
     "solidity-coverage": "^0.8.1",
     "ts-node": ">=8.0.0",
-    "typechain": "^8.3.0",
     "typescript": ">=4.5.0",
     "viem": "^2.0.0"
   },


### PR DESCRIPTION
Closes #407.

## The choice

The issue asks to pick a direction — wire TypeChain in, or remove it. **Removed**, because the template is viem all the way down:

| | |
|---|---|
| `hardhat.config.ts.hbs:2` | imports `@nomicfoundation/hardhat-toolbox-viem` and nothing else |
| `test/Lock.ts.hbs` | imports from `hardhat-toolbox-viem/network-helpers`, uses `getAddress`/`parseGwei` from `viem` |
| `ignition/modules/Lock.ts.hbs` | uses `parseEther` from `viem` |

TypeChain generates **ethers** bindings. That is precisely why `hardhat-toolbox-viem` drops it. Wiring it back in would add a second type system that nothing in the template uses, on top of the type inference the viem toolbox already provides from compiled artifacts.

## Removed

- `@typechain/ethers-v6`, `@typechain/hardhat`, `typechain` from devDependencies
- the `"typechain": "hardhat typechain"` script — the task does not exist, so it only ever produced `Error HH303: Unrecognized task 'typechain'`
- `typechain-types/**` from the turbo `compile` outputs, an output that could never be produced
- `@nomicfoundation/hardhat-toolbox` — declared at line 32, never imported anywhere

## Docs

`docs/integrations/contracts/hardhat.mdx:19` advertised *"TypeChain Support: Automatically generated TypeScript bindings"* — directly **below** a bullet saying the tests use Viem. The two contradicted each other. Replaced with what the setup actually gives you: the Viem toolbox infers types from compiled artifacts, with no separate generation step.

## Verified

`create demo -t basic -c hardhat`, then compile and test with all of the above removed:

```
hardhat:compile: Compiled 1 Solidity file successfully (evm target: paris).
hardhat:test:    8 passing (874ms)
Tasks: 2 successful, 2 total
```

Nothing was relying on any of it.

**One note on reproducing this:** a hardhat scaffold from `main` cannot compile at all right now — `hardhat.config.ts` is invalid TypeScript (#399, fixed in #427). I applied that one fix to the generated project to get a compile at all, so the run above isolates this change. Worth knowing that #427 gates verification of every other hardhat change.

## Conflict note

This touches `templates/base/turbo.json.hbs`, which #430 also edits — different hunk (#430 adds a `foundry` branch after the hardhat one; this edits a line inside the hardhat one), so they should merge cleanly in either order.