### PR TITLE
fix(templates): stub the optional peers wagmi's connectors import statically

### DIFF
--- a/templates/base/apps/web/next.config.js.hbs
+++ b/templates/base/apps/web/next.config.js.hbs
@@ -3,6 +3,40 @@ const nextConfig = {
   reactStrictMode: true,
   webpack: (config) => {
     config.externals.push('pino-pretty', 'lokijs', 'encoding')
+
+    // Optional dependencies the wallet stack imports but a web build never uses.
+    //
+    // wagmi's connectors pull in @base-org/account, which pulls in
+    // @coinbase/cdp-sdk. That SDK declares @x402/core, @x402/evm,
+    // @x402/extensions and @x402/svm as OPTIONAL peer dependencies — so a
+    // package manager correctly does not install them — and then imports them
+    // STATICALLY. webpack resolves static imports at build time, so a default
+    // scaffold fails with "Can't resolve '@x402/evm/upto/client'" before any of
+    // your own code is reached.
+    //
+    // Only the ones genuinely absent are stubbed. Install them to use CDP's
+    // x402 support and this loop stops matching, so they bundle normally.
+    // @metamask/sdk does the same with its React Native storage backend.
+    //
+    // Stubbed through resolve.alias rather than externals: a bare string in
+    // externals becomes a global variable reference, and a scoped package name
+    // is not a valid identifier — that turns the warning into an unparseable
+    // module and fails the build outright.
+    const optionalPeers = [
+      '@x402/core',
+      '@x402/evm',
+      '@x402/extensions',
+      '@x402/svm',
+      '@react-native-async-storage/async-storage',
+    ]
+    for (const pkg of optionalPeers) {
+      try {
+        require.resolve(pkg)
+      } catch {
+        config.resolve.alias = { ...config.resolve.alias, [pkg]: false }
+      }
+    }
+
     return config
   },
 };


### PR DESCRIPTION
Closes #398.

I opened that issue saying the choice was not mine to make, and offered three directions. Having dug into it, **none of the three is the right fix**, so this takes a fourth — and deliberately does not force the stack decision either way.

## What is actually wrong

Reproduced on current `main` — and it is worse than the issue recorded, five modules rather than two:

```
Module not found: Can't resolve '@x402/evm/upto/client'
Module not found: Can't resolve '@x402/evm/exact/client'
Module not found: Can't resolve '@x402/core/client'
Module not found: Can't resolve '@x402/svm/exact/client'
Module not found: Can't resolve '@x402/evm'
```

The chain is `@rainbow-me/rainbowkit → wagmi → @wagmi/connectors → @base-org/account → @coinbase/cdp-sdk`. And `@coinbase/cdp-sdk@1.55.0` declares:

```json
"peerDependencies":     { "@x402/core": "^2.21.0", "@x402/evm": "^2.21.0",
                          "@x402/extensions": "^2.21.0", "@x402/svm": "^2.21.0" },
"peerDependenciesMeta": { "@x402/core": { "optional": true }, ... all four optional }
```

**They are optional peers, and the SDK imports them statically.** A package manager is right not to install an optional peer. webpack is right to resolve a static import at build time. Both cannot hold, so any consumer that bundles this SDK breaks — this is an upstream contradiction, not our version drift.

That reframes the three options in the issue. Narrowing the ranges or shipping a lockfile only pins away from today's version; the contradiction is still there and returns on the next bump. Bumping to Next 16 / React 19 is a real decision with its own testing pass, and it should not be forced by a bug that has nothing to do with it.

## The fix

```js
const optionalPeers = ['@x402/core', '@x402/evm', '@x402/extensions', '@x402/svm',
                       '@react-native-async-storage/async-storage']
for (const pkg of optionalPeers) {
  try { require.resolve(pkg) } catch {
    config.resolve.alias = { ...config.resolve.alias, [pkg]: false }
  }
}
```

Three properties worth noting:

- **It is the pattern this config already uses.** `pino-pretty`, `lokijs` and `encoding` are on the `externals` line directly above for exactly this reason. These are the same class, one level deeper.
- **It only applies to what is genuinely missing.** `require.resolve` decides. Install the `@x402/*` packages to use CDP's x402 support and the loop stops matching them, so they bundle normally. Nothing is permanently blocked.
- **`@metamask/sdk`'s React Native storage backend joins the list** — it was producing a build warning of the same kind.

## Why `resolve.alias` and not `externals`

I tried `externals` first, since that is what the line above uses. It **turned a warning into a hard failure**:

```
Caused by:
    0: failed to parse input file
    1: Syntax Error
```

A bare string in `externals` becomes a global variable reference in the client bundle, and `@react-native-async-storage/async-storage` is not a valid identifier, so the generated stub does not parse. `resolve.alias` to `false` emits an empty module instead. Recording it because the wrong one looks more idiomatic here.

## Verified

`create demo -t basic -c none`, then `pnpm --filter web build`:

| | |
|---|---|
| before | 5 × `Module not found: Can't resolve '@x402/…'`, build failed |
| after | all five resolved; build reaches type-checking |

Type-checking then fails on `navbar.tsx` — which is #396, fixed in #397. **With that one-line import fix applied on top, the scaffold builds all the way through for the first time:**

```
✓ Generating static pages (4/4)
Route (app)                    Size     First Load JS
+ First Load JS shared by all  90 kB
```

One warning remains, `Critical dependency: the request of a dependency is an expression` from `ox` (a viem dependency). That is a dynamic require inside a third-party package, and not something a template's webpack config should paper over.

## What this does not decide

The version table in the issue still stands — `next ^14.0.0` against 16.3.0, `react ^18.2.0` against 19.2.8, and `@x402/next` needing `next >= 16.2.6`. **That decision is still open and still yours.** This just means a default scaffold builds while it is being made.