### PR TITLE
fix(templates): mount the farcaster wallet stack once, not twice

### DIFF
--- a/templates/farcaster-miniapp/apps/web/src/contexts/miniapp-context.tsx.hbs
+++ b/templates/farcaster-miniapp/apps/web/src/contexts/miniapp-context.tsx.hbs
@@ -11,7 +11,6 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import FrameWalletProvider from "./frame-wallet-context";
 
 interface MiniAppContextType {
   isMiniAppReady: boolean;
@@ -87,7 +86,7 @@ export function MiniAppProvider({ children, addMiniAppOnLoad }: MiniAppProviderP
         context,
       }}
     >
-      <FrameWalletProvider>{children}</FrameWalletProvider>
+      {children}
     </MiniAppContext.Provider>
   );
 }


### PR DESCRIPTION
Closes #404.

## The bug

`providers.tsx.hbs` composes the tree explicitly:

```tsx
<FrameWalletProvider>
  <MiniAppProvider addMiniAppOnLoad={true}>{children}</MiniAppProvider>
</FrameWalletProvider>
```

and `miniapp-context.tsx.hbs:90` wrapped its children in `<FrameWalletProvider>` **again**. Since that provider calls `createConfig()` and mounts `WagmiProvider` + `QueryClientProvider`, a generated app ran the whole stack twice, nested — components resolving hooks against the inner config, anything rendered between the two layers against the outer, and two independent query caches.

## Why removing the inner one is the safe direction

Checked before cutting, rather than assuming the outer wrapper covers everything:

- **`MiniAppProvider` has exactly one usage** — `providers.tsx.hbs:16` — and it is already inside `FrameWalletProvider`. There is no call site that depends on it supplying its own wallet context.
- **`miniapp-context` calls no wagmi hooks itself** (no `useAccount` / `useConnect` / `useConfig`), so it needs nothing from the provider it was mounting.

So the outer composition already covers every consumer, and removing the inner wrapper takes coverage away from nothing.

Removing it orphaned `import FrameWalletProvider from "./frame-wallet-context"`, so that went too.

## Verified

Mount points, counted in the templates:

| | `providers.tsx` | `miniapp-context.tsx` |
|---|---|---|
| main | 1 | 1 |
| this branch | 1 | 0 |

And in a generated `-t farcaster-miniapp` project, `WagmiProvider` / `QueryClientProvider` now appear only in `contexts/frame-wallet-context.tsx`, reached through the single mount in `providers.tsx`. `pnpm type-check` passes.