### PR TITLE
fix(cli): resolve templates/ by walking up, not by a fixed level

### DIFF
--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -14,32 +14,33 @@ export function getDirname(importMetaUrl: string): string {
  */
 export function getTemplatesPath(importMetaUrl: string): string {
   const currentDir = getDirname(importMetaUrl);
-  // At runtime, we're in dist/, so go up to package root, then into templates/
-  // During development, we might be in src/, so handle both cases - (added currentDir.includes('\\dist') || to also handle Windows paths)
-  const isInDist = currentDir.includes('/dist') || currentDir.includes('\\dist') || currentDir.endsWith('/dist') || currentDir.includes('\\dist') ;
-  let templatesPath: string;
 
-  if (isInDist) {
-    // From dist/generators/ or dist/utils/ go up to package root, then into templates/
-    templatesPath = join(currentDir, '..', 'templates');
-  } else {
-    // dev mode: we might be in src or src/**
-    const inSrcSubdir = currentDir.includes('/src/') || currentDir.includes('\\src\\');
-    const inSrcRoot = currentDir.endsWith('/src') || currentDir.endsWith('\\src');
-
-    if (inSrcSubdir) {
-      // From src/ go up to package root, then into templates/
-      // e.g. .../celo-composer/src/generators -> go up twice to reach repo root
-      templatesPath = join(currentDir, '..', '..', 'templates');
-    } else if (inSrcRoot) {
-      // e.g. .../celo-composer/src -> go up once to reach repo root
-      templatesPath = join(currentDir, '..', 'templates');
-    } else {
-    // Fallback: safest default, go up one level
-    templatesPath = join(currentDir, '..', 'templates');
+  // Walk up until a directory actually contains templates/, rather than
+  // hardcoding how many levels up the caller happens to sit.
+  //
+  // This used to branch on dist-vs-src and then apply a fixed `..` for dist,
+  // which is only correct for a caller at dist/ root. plopfile.js is there, so
+  // it worked; plop-generator.js is at dist/generators/, so it resolved to
+  // <pkg>/dist/templates — a directory that has never existed. The ai-chat
+  // template is the only one that goes through that path, which is why it was
+  // the only template that could not be scaffolded at all.
+  //
+  // Depth-independent so moving a caller cannot reintroduce it.
+  let dir = currentDir;
+  for (let i = 0; i < 6; i += 1) {
+    const candidate = join(dir, 'templates');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
-}
-  return templatesPath;
+
+  // Nothing found. Return the historically-correct guess so the caller reports
+  // a missing template rather than a missing directory two levels up.
+  const isInDist = currentDir.includes('/dist') || currentDir.includes('\\dist');
+  return isInDist
+    ? join(currentDir, '..', 'templates')
+    : join(currentDir, '..', '..', 'templates');
 }
 
 /**


### PR DESCRIPTION
Addresses issue 1 of #387 — the scaffolding failure. The deployability half of that issue is untouched here.

## The bug

`getTemplatesPath` branched on dist-vs-src and then, for dist, applied a fixed single `..`:

```ts
if (isInDist) {
  templatesPath = join(currentDir, '..', 'templates');
}
```

That is correct for exactly one of its two callers:

| caller | `currentDir` | resolves to | |
|---|---|---|---|
| `dist/plopfile.js` | `<pkg>/dist` | `<pkg>/templates` | ✅ |
| `dist/generators/plop-generator.js` | `<pkg>/dist/generators` | `<pkg>/dist/templates` | ❌ |

`ai-chat` is the only template that goes through the raw-copy path in `plop-generator.ts`, which is why it is the only one that fails — everything else is plop-driven and reads the path computed in `plopfile.js`.

**Reproduced against the published package**, not just a local checkout:

```
$ npx @celo/celo-composer@2.4.13 create demo -t ai-chat --skip-install -y
ENOENT: no such file or directory, lstat
  '.../node_modules/@celo/celo-composer/dist/templates/ai/chat-template'
```

Worth noting the dev branch of the same function *already* handled this — it distinguishes `inSrcSubdir` (up twice) from `inSrcRoot` (up once). The dist branch never got the same treatment, and the comment above it says "From dist/generators/ or dist/utils/ go up to package root", which is what it intended and not what one `..` does from those directories.

## The fix

Walk up from the calling module until a directory containing `templates/` is found:

```ts
let dir = currentDir;
for (let i = 0; i < 6; i += 1) {
  const candidate = join(dir, 'templates');
  if (existsSync(candidate)) return candidate;
  const parent = dirname(dir);
  if (parent === dir) break;
  dir = parent;
}
```

Depth-independent, so moving a caller cannot reintroduce this, and it removes the branching that was carrying the same fixed-depth assumption in two places. The fallback below keeps the old guess, so a genuinely missing `templates/` still reports as a missing template rather than a path two levels away.

## Verified

| scaffold | before | after |
|---|---|---|
| `-t ai-chat` | ENOENT, no project | scaffolds, 20 entries |
| `-t basic` | ✅ | ✅ web + contracts |
| `-t minipay` | ✅ | ✅ web + contracts |
| `-t farcaster-miniapp` | ✅ | ✅ web |
| `-t basic -c foundry` | ✅ | ✅ contracts |

`tsc --noEmit` clean.

## Note for whoever sequences this

**This gates #424.** That issue is hygiene *inside* the ai-chat template — a test-mock import in production code, a committed 1 MB `tsbuildinfo`, React 18 types beside a React 19 RC — and none of it can be verified end to end while the template cannot be generated at all. I have that PR ready and will verify it against this once it lands.