### PR TITLE
fix(build): stash pruned files outside the package, not inside it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .env
 dist
+# leftover from an interrupted pnpm pack (older versions stashed here)
+.prune-stash/

--- a/scripts/postpack-restore.cjs
+++ b/scripts/postpack-restore.cjs
@@ -2,26 +2,53 @@
 /* eslint-disable no-console */
 const fs = require('fs-extra');
 const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
 
 const ROOT = path.join(__dirname, '..');
 const TEMPLATE_PATH = path.join(ROOT, 'templates', 'ai', 'chat-template');
-const STASH_DIR = path.join(TEMPLATE_PATH, '.prune-stash');
+
+// Must match prepack-prune.cjs exactly — same derivation, no shared state.
+const STASH_KEY = crypto.createHash('sha256').update(ROOT).digest('hex').slice(0, 12);
+const STASH_DIR = path.join(os.tmpdir(), `celo-composer-prune-${STASH_KEY}`);
+
+// Where the stash used to live, inside the packed tree. Cleaned up if an older
+// version of these scripts left one behind, so a stale directory cannot be
+// picked up by a later pack.
+const LEGACY_STASH_DIR = path.join(TEMPLATE_PATH, '.prune-stash');
 
 (async () => {
   try {
+    if (await fs.pathExists(LEGACY_STASH_DIR)) {
+      const legacyManifest = path.join(LEGACY_STASH_DIR, 'manifest.json');
+      if (await fs.pathExists(legacyManifest)) {
+        for (const item of await fs.readJson(legacyManifest)) {
+          const destPath = path.join(TEMPLATE_PATH, item.rel);
+          if (await fs.pathExists(item.dest)) {
+            await fs.ensureDir(path.dirname(destPath));
+            await fs.move(item.dest, destPath, { overwrite: true });
+            console.log(`[postpack] restored ${item.rel} from the legacy stash`);
+          }
+        }
+      }
+      await fs.remove(LEGACY_STASH_DIR);
+    }
+
     if (!(await fs.pathExists(STASH_DIR))) return;
     const manifestPath = path.join(STASH_DIR, 'manifest.json');
     if (!(await fs.pathExists(manifestPath))) return;
     const manifest = await fs.readJson(manifestPath);
     for (const item of manifest) {
-      const destRel = item.rel;
-      const destPath = path.join(TEMPLATE_PATH, destRel);
+      const destPath = path.join(TEMPLATE_PATH, item.rel);
       await fs.ensureDir(path.dirname(destPath));
       await fs.move(item.dest, destPath, { overwrite: true });
-      console.log(`[postpack] restored ${destRel}`);
+      console.log(`[postpack] restored ${item.rel}`);
     }
     await fs.remove(STASH_DIR);
   } catch (err) {
-    console.warn('[postpack] restore step failed (continuing):', err);
+    // Loud, because the working tree is now missing whatever was stashed. The
+    // stash directory is printed so it can be restored by hand.
+    console.error(`[postpack] restore FAILED — files are still in ${STASH_DIR}:`, err);
+    process.exitCode = 1;
   }
 })();

--- a/scripts/prepack-prune.cjs
+++ b/scripts/prepack-prune.cjs
@@ -2,10 +2,25 @@
 /* eslint-disable no-console */
 const fs = require('fs-extra');
 const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
 
 const ROOT = path.join(__dirname, '..');
 const TEMPLATE_PATH = path.join(ROOT, 'templates', 'ai', 'chat-template');
-const STASH_DIR = path.join(TEMPLATE_PATH, '.prune-stash');
+
+// OUTSIDE the package root, deliberately.
+//
+// This used to stash into templates/ai/chat-template/.prune-stash — a directory
+// inside the tree being packed. `templates` is in the package `files` list, and
+// npm's implicit ignores only cover some of these names at depth, so `.next` and
+// tsconfig.tsbuildinfo were re-entering the tarball under .prune-stash/ and
+// whether a stashed .env leaked depended on the package manager version. The
+// prune achieved the opposite of its purpose.
+//
+// Keyed on ROOT so two checkouts packing at once cannot collide, and derived the
+// same way in postpack-restore.cjs — the two must agree without passing state.
+const STASH_KEY = crypto.createHash('sha256').update(ROOT).digest('hex').slice(0, 12);
+const STASH_DIR = path.join(os.tmpdir(), `celo-composer-prune-${STASH_KEY}`);
 
 const pathsToPrune = [
   '.git',
@@ -25,7 +40,7 @@ const pathsToPrune = [
     for (const rel of pathsToPrune) {
       const src = path.join(TEMPLATE_PATH, rel);
       if (await fs.pathExists(src)) {
-        const dest = path.join(STASH_DIR, rel.replace(/[\/]/g, '__')); // flatten
+        const dest = path.join(STASH_DIR, rel.replace(/[/]/g, '__')); // flatten
         await fs.move(src, dest, { overwrite: true });
         manifest.push({ rel, dest });
         console.log(`[prepack] pruned ${rel}`);
@@ -35,6 +50,10 @@ const pathsToPrune = [
       spaces: 2,
     });
   } catch (err) {
-    console.warn('[prepack] prune step failed (continuing):', err);
+    // NOT "continuing". This step exists to keep .env and .env.local out of a
+    // published tarball; a warning that scrolls past means the next thing that
+    // happens is a publish containing them. Better to fail the pack.
+    console.error('[prepack] prune step FAILED — refusing to pack:', err);
+    process.exitCode = 1;
   }
 })();


### PR DESCRIPTION
Closes #413.

## The mechanism was self-defeating

`prepack-prune.cjs` moved the files it wanted to exclude into `templates/ai/chat-template/.prune-stash/` — **inside the tree being packed**. `templates` is in the package `files` list, so npm's implicit ignores only caught some of them at that depth, and the rest shipped under the stash path instead of their original one.

**Measured on `main`**, with a `.next/` present in the template as any developer who ran it locally would have:

```
$ pnpm pack && tar -tzf celo-celo-composer-2.4.13.tgz | grep -c prune-stash
3869
```

Including `package/templates/ai/chat-template/.prune-stash/tsconfig.tsbuildinfo`.

pnpm 10.13 happened to drop the stashed `.env`. That is luck, not design — the issue already notes it varies by package manager, and nothing in the mechanism prevents an env file from shipping.

## The fix

Stash in `os.tmpdir()`, keyed on a hash of the package root:

```js
const STASH_KEY = crypto.createHash('sha256').update(ROOT).digest('hex').slice(0, 12);
const STASH_DIR = path.join(os.tmpdir(), `celo-composer-prune-${STASH_KEY}`);
```

Derived identically in both scripts, so they agree without passing state, and keyed on ROOT so two checkouts packing concurrently cannot collide.

`postpack` also drains and removes a legacy `.prune-stash/` if an older version of these scripts left one in the tree — otherwise a stale one sits there until someone notices. `.gitignore` covers it regardless, per the issue.

## One thing beyond the issue: both scripts now fail rather than warn

```js
} catch (err) {
  console.error('[prepack] prune step FAILED — refusing to pack:', err);
  process.exitCode = 1;
}
```

The previous `console.warn('...(continuing)')` is the wrong default for a step whose entire job is keeping `.env` and `.env.local` out of a published tarball. A warning scrolls past and the publish proceeds. Same treatment on `postpack`, where a failure means the working tree is missing whatever was stashed — it now says so and prints the stash path so it can be recovered by hand.

## Verified

Same fixtures — `.next/`, `.env`, `tsconfig.tsbuildinfo` all present before packing:

| | main | this branch |
|---|---|---|
| `.prune-stash` entries in tarball | 3,869 | **0** |
| `chat-template/.next` entries | present | **0** |
| `tsbuildinfo` | present | **0** |
| stray `.env` | 0 (pnpm luck) | **0** |

And all three are restored to the working tree afterwards, with the temp stash removed.

## Not included

The issue also notes the prune list has drifted from `src/utils/safe-copy.ts`, and that `tests/`, `playwright.config.ts`, `.github/` and `.vscode/` currently ship in the tarball. Deciding what *should* ship is a package-size call rather than a correctness one, so I have left it — happy to take it as a follow-up if you want the two lists reconciled.