### PR TITLE
fix(cli): report the real version, not a hardcoded 1.0.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,23 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { createRequire } from 'node:module';
 import { createCommand } from './commands/create.js';
 import chalk from 'chalk';
+
+// Read at runtime rather than importing package.json, which would pull it into
+// the compiled tree and move dist/ around. `..` resolves to the package root
+// from dist/index.js and from src/index.ts alike, so `--version` is right under
+// both `node dist/index.js` and `tsx src/index.ts`.
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json') as { version: string };
 
 const program = new Command();
 
 program
   .name('celo-composer')
   .description('CLI tool for generating customizable Celo blockchain starter kits')
-  .version('1.0.0');
+  .version(version);
 
 program
   .command('create')


### PR DESCRIPTION
Closes #409.

`src/index.ts:12` hardcoded `.version('1.0.0')` against a `package.json` at `2.4.13`. The number has never matched a published release, so a bug report quoting `celo-composer --version` identifies nothing.

## Why `createRequire` rather than importing the JSON

`import pkg from '../package.json'` works, but with `outDir: dist` it pulls `package.json` into the compiled tree and shifts the `dist/` layout — `dist/src/index.js` instead of `dist/index.js`, which breaks the `bin` entry and the templates path. A runtime read avoids touching the build shape at all:

```ts
const require = createRequire(import.meta.url);
const { version } = require('../package.json') as { version: string };
```

`..` resolves to the package root from `dist/index.js` **and** from `src/index.ts`, so it is correct under both entry points, and `package.json` is always present in a published tarball.

## Verified

```
node dist/index.js --version   → 2.4.13
tsx src/index.ts --version     → 2.4.13
package.json                   → 2.4.13
```

`tsc --noEmit` clean.