### PR TITLE
fix(cli): let a flag bypass its own prompt, not all of them

### DIFF
--- a/docs/cli-reference/create-command.mdx
+++ b/docs/cli-reference/create-command.mdx
@@ -43,8 +43,10 @@ npx @celo/celo-composer@latest create my-awesome-dapp
 
 Create a new project with specific configurations by using flags. This is useful for scripting and automation.
 
+**A flag only skips its own question.** `--template` answers the template prompt and nothing else, so anything you leave out is still asked. In a script or a CI job there is nobody to answer, and the command stops there — so **add `-y` whenever the run has no terminal attached**. It accepts the defaults for every question your flags did not already answer, and your flags still win where you gave them.
+
 ```bash
-npx @celo/celo-composer@latest create --template minipay
+npx @celo/celo-composer@latest create my-minipay-app --template minipay -y
 ```
 
 This command creates a new project using the Minipay template, which is optimized for integration with the Minipay mobile wallet. It comes with a pre-configured wallet connection and a mobile-first UI.
@@ -53,14 +55,16 @@ This command creates a new project using the Minipay template, which is optimize
 npx @celo/celo-composer@latest create my-farcaster-app \
   --template farcaster-miniapp \
   --wallet-provider thirdweb \
-  --contracts none
+  --contracts none \
+  -y
 ```
 
 ```bash
 npx @celo/celo-composer@latest create my-ai-chat \
   --template ai-chat \
   --contracts none \
-  --wallet-provider none
+  --wallet-provider none \
+  -y
 ```
 
 The `ai-chat` template is a standalone Next.js app copied as-is (no Handlebars rendering). Wallet and contracts prompts are skipped by default.

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -44,23 +44,28 @@ export async function createCommand(
   try {
     console.log(chalk.blue.bold("\n🟨 Welcome to Celo Composer CLI!\n"));
 
-    // If --yes flag is provided, skip all prompts and use defaults/flags
-    // Check if any CLI options are provided (auto-mode)
-    const hasCliOptions = !!(
-      options.description ||
-      options.template ||
-      options.templateType ||
-      options.walletProvider ||
-      options.contracts ||
-      options.skipInstall ||
-      options.yes
-    );
+    // `-t` populates options.template; only the long `--template-type` sets
+    // templateType. Several reads below checked just one of the two, which was
+    // harmless while any flag skipped the prompts entirely and is not once they
+    // run: the template question would re-ask, and finalTemplateType would fall
+    // through to "basic" for a `-t minipay` that had no -y. Normalised once.
+    const cliTemplateType = options.template || options.templateType;
 
+    // Only -y skips the prompts.
+    //
+    // This used to skip them whenever ANY flag was present, so
+    // `create myapp -d "hello"` silently produced basic + rainbowkit + hardhat
+    // without asking a single question — and made -y redundant, since every
+    // other flag already did what it does. The docs describe the opposite:
+    // a flag bypasses the prompt "for those options", leaving the rest asked.
+    //
+    // The per-question `when:` clauses below already implement that, keyed on
+    // the specific flag. They were simply never reached.
     const answers: PromptAnswers =
-      options.yes || hasCliOptions
+      options.yes
         ? ((): PromptAnswers => {
             const autoTemplateType =
-              options.template || options.templateType || "basic";
+              cliTemplateType || "basic";
             const autoWallet = options.walletProvider
               ? options.walletProvider
               : autoTemplateType === "farcaster-miniapp" ||
@@ -112,7 +117,10 @@ export async function createCommand(
                 { name: "AI Agent Chat App", value: "ai-chat" },
               ],
               default: "basic",
-              when: !options.templateType,
+              // `-t` populates options.template; only the long form sets
+              // templateType. Checking one of the two asks again for a template
+              // the user already chose.
+              when: !cliTemplateType,
             },
             {
               type: "list",
@@ -126,7 +134,7 @@ export async function createCommand(
               default: "rainbowkit",
               when: (answers: { templateType?: string }): boolean => {
                 const templateType =
-                  options.templateType || answers.templateType;
+                  cliTemplateType || answers.templateType;
                 return (
                   !options.walletProvider &&
                   templateType !== "farcaster-miniapp" &&
@@ -151,7 +159,7 @@ export async function createCommand(
               default: "hardhat",
               when: (answers: { templateType?: string }): boolean => {
                 const templateType =
-                  options.templateType || answers.templateType;
+                  cliTemplateType || answers.templateType;
                 if (templateType === "ai-chat") return false;
                 return !options.contracts;
               },
@@ -181,7 +189,7 @@ export async function createCommand(
       answers.description ||
       "A new Celo blockchain project";
     const finalTemplateType =
-      options.templateType || answers.templateType || "basic";
+      cliTemplateType || answers.templateType || "basic";
 
     // Farcaster miniapp specific prompts - only ask if template is farcaster-miniapp and values not provided via CLI
     let farcasterAnswers: {


### PR DESCRIPTION
Closes #411.

## The bug

```bash
npx @celo/celo-composer create myapp -d "hello"
# no prompts at all → basic + rainbowkit + hardhat
```

`hasCliOptions` was true if *any* of seven flags was set, and that switched off the whole prompt block. So adding a description silently chose a wallet provider and a contract framework, and `-y` was redundant — every other flag already did what it does.

`docs/cli-reference/create-command.mdx:21` documents the opposite: a flag bypasses the prompts **"for those options"**.

**The per-question `when:` clauses already implement that**, keyed on the specific flag. They were never reached. So the fix is that only `-y` skips.

## The second bug, which the first was hiding

`-t` populates `options.template`. Only the long `--template-type` would set `options.templateType`, and **four reads checked only the latter**:

| line | read | consequence once prompts run |
|---|---|---|
| template prompt `when:` | `!options.templateType` | re-asks for a template already chosen |
| wallet `when:` | `options.templateType \|\| answers.templateType` | asks minipay for a wallet provider it forces itself |
| contracts `when:` | same | same shape |
| **`finalTemplateType`** | `options.templateType \|\| answers.templateType \|\| "basic"` | **`-t minipay` generates a `basic` project** |

That last one is the serious one, and it is only reachable *after* fixing the bypass — the auto-mode branch computed it correctly, so nothing was wrong while every flag went down that path. Removing the bypass without this would have broken `-t` outright.

Normalised into a single `cliTemplateType` at the top rather than patching four sites, so a fifth read cannot repeat it.

## Verified

Prompts driven through stdin, recording which questions each invocation asks:

| invocation | asks |
|---|---|
| `-d hello` | template, wallet — **not** description |
| `-t minipay` | description, contracts — **not** template, **not** wallet |
| `-t basic` | description, wallet — **not** template |
| `-y` | nothing |

And that `-t` still reaches generation, checked on a file unique to each template:

```
-t minipay            → apps/web/src/components/user-balance.tsx   PRESENT
-t farcaster-miniapp  → apps/web/src/contexts/miniapp-context.tsx  PRESENT
-t basic              → apps/contracts/hardhat.config.ts           PRESENT
```

`tsc --noEmit` clean. `-y` scaffolds exactly as before.

## Conflict note

~~This touches `src/commands/create.ts`, which #393 and #430 also modify — different hunks … so they should merge in any order.~~ **Stale, and wrong now.** Re-checked against the current heads: **#393 conflicts.**

```
$ git merge --no-ff x393
CONFLICT (content): Merge conflict in src/commands/create.ts
```

The heads moved after this note was written — #393 now rewrites the same auto-mode block and the same `when:` clauses this PR normalises. **#430 still merges clean.**

**Recommended order, which is the reviewer's: this PR first, #393 rebases last.** On that rebase #393 needs two things, both known: `'x402'` added to #442's `.choices()` list, and its x402 `when:` conditions re-threaded onto `cliTemplateType` — the current clauses read `options.templateType`, which is exactly the field this PR normalises away because it misses `-t`.

## Behavioural break — worth a release note

**This is a deliberate break for anything that relied on the old any-flag auto-mode.** `create app -t basic --skip-install` in CI used to run silently to completion; it now stops at the description prompt. That is the documented behaviour restored (#411), not a regression, but it changes what an existing script does with no error message to explain it.

The release-note line belongs in the CHANGELOG, which **#446** currently rewrites end to end — adding it here would collide with that PR for no benefit, so it goes in #446's `[Unreleased]` section and is noted on both.
