### PR TITLE
fix(cli): pass the farcaster miniapp answers to the generator

### DIFF
--- a/src/generators/plop-generator.ts
+++ b/src/generators/plop-generator.ts
@@ -36,6 +36,10 @@ export class TemplateGenerator {
       walletProvider,
       contractFramework,
       projectPath,
+      miniappName,
+      miniappDescription,
+      miniappTags,
+      miniappTagline,
     } = config;
 
     try {
@@ -78,6 +82,12 @@ export class TemplateGenerator {
       const generator = plopInstance.getGenerator("celo-project");
 
       // Run the generator with the provided configuration
+      // The four miniapp values are prompted for, resolved, forwarded through
+      // project-generator and declared on PlopConfig — and were then dropped
+      // here, the last step before the templates see them. layout.tsx.hbs and
+      // warpcast.ts.hbs are full of `{{#if miniappName}}` branches whose
+      // condition was therefore always false, so every farcaster project shipped
+      // the generic {{else}} fallbacks no matter what the user typed.
       const results = await generator.runActions({
         projectName,
         description,
@@ -85,6 +95,10 @@ export class TemplateGenerator {
         walletProvider,
         contractFramework,
         projectPath,
+        miniappName,
+        miniappDescription,
+        miniappTags,
+        miniappTagline,
       });
 
       // Check if generation was successful


### PR DESCRIPTION
Closes #410.

The four miniapp values travel almost the whole way and are dropped at the last step:

| stage | file | |
|---|---|---|
| prompted and resolved | `create.ts:194-285` | ✅ |
| passed to `generateProject` | `create.ts:339-342` | ✅ |
| forwarded into the Plop config | `project-generator.ts:55-58` | ✅ |
| declared on `PlopConfig` | `plop-generator.ts:17-21` | ✅ |
| **handed to `runActions`** | `plop-generator.ts:81-88` | ❌ |

So `layout.tsx.hbs` and `warpcast.ts.hbs`, which are full of `{{#if miniappName}}` branches, always took the `{{else}}` fallback — every farcaster project shipped generic metadata no matter what the user typed.

## Verified

`create my-fc-app -t farcaster-miniapp`, accepting the prompt defaults. The miniapp-name default is the project name title-cased, while the fallback is the raw project name, which makes the two paths easy to tell apart:

**`apps/web/src/app/layout.tsx`**
```
before   title: "Launch my-fc-app"      title: 'my-fc-app'
after    title: "Launch My Fc App"      title: 'My Fc App'
```

**`apps/web/src/lib/warpcast.ts`**
```
before   description: "A new Celo blockchain project"   tags: ["mini-app", "celo"]
after    description: "A new Celo blockchain miniapp"   tags: "mini-app,celo,blockchain".split(",")
```

`tagline` is unchanged in that comparison only because its prompt default happens to equal the hardcoded fallback.

## On the related inconsistency in the issue

The issue notes the miniapp prompts fire on `!options.yes` rather than the `hasCliOptions` check used everywhere else, so `create app -t farcaster-miniapp` prompted for these four and nothing else. **That resolves itself once #411 lands** — #440 removes `hasCliOptions` entirely, so every prompt including these keys off `-y` and its own flag. Left alone here to keep the two PRs separable; this one is purely the data plumbing.