### PR TITLE
fix(cli): reject unknown flag values, and emit an npm-legal package name

### DIFF
--- a/src/generators/plop-generator.ts
+++ b/src/generators/plop-generator.ts
@@ -3,6 +3,7 @@ import nodePlop from "node-plop";
 import path from "path";
 import { safeCopyTemplate } from "../utils/safe-copy.js";
 import { getTemplatesPath, getPlopfilePath } from "../utils/paths.js";
+import { toPackageName } from "../utils/validation.js";
 
 // TypeScript compilation handles TS support - no runtime tsx needed
 
@@ -62,7 +63,9 @@ export class TemplateGenerator {
         const pkgPath = path.join(projectPath, "package.json");
         if (await fs.pathExists(pkgPath)) {
           const pkg = JSON.parse(await fs.readFile(pkgPath, "utf8")) as Record<string, unknown>;
-          (pkg as { name?: string }).name = projectName;
+          // This path never reaches Plop, so the kebabCase helper never runs —
+          // normalise here through the same function the helper uses.
+          (pkg as { name?: string }).name = toPackageName(projectName);
           // Normalize version for new project scaffolds
           (pkg as { version?: string }).version = "0.1.0";
           await fs.writeFile(pkgPath, JSON.stringify(pkg, null, 2) + "\n");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { createRequire } from 'node:module';
 import { createCommand } from './commands/create.js';
 import chalk from 'chalk';
@@ -24,9 +24,32 @@ program
   .description('Create a new Celo project')
   .argument('[project-name]', 'Name of the project')
   .option('-d, --description <description>', 'Project description')
-  .option('-t, --template <type>', 'Template type (basic, farcaster-miniapp, minipay, ai-chat)')
-  .option('--wallet-provider <provider>', 'Wallet provider (rainbowkit, thirdweb, none)')
-  .option('-c, --contracts <framework>', 'Smart contract framework (hardhat, foundry, none)')
+  // .choices() rather than a bare string, so an unknown value is rejected with
+  // the allowed list instead of flowing into Plop — where every
+  // `{{#if (eq templateType ...)}}` is simply false and the user silently gets a
+  // bare base project that matches nothing documented.
+  .addOption(
+    new Option('-t, --template <type>', 'Template type').choices([
+      'basic',
+      'farcaster-miniapp',
+      'minipay',
+      'ai-chat',
+    ])
+  )
+  .addOption(
+    new Option('--wallet-provider <provider>', 'Wallet provider').choices([
+      'rainbowkit',
+      'thirdweb',
+      'none',
+    ])
+  )
+  .addOption(
+    new Option('-c, --contracts <framework>', 'Smart contract framework').choices([
+      'hardhat',
+      'foundry',
+      'none',
+    ])
+  )
   .option('--skip-install', 'Skip package installation')
   .option('-y, --yes', 'Skip all prompts and use defaults')
   .action(createCommand);

--- a/src/plopfile.ts
+++ b/src/plopfile.ts
@@ -1,6 +1,7 @@
 import { NodePlopAPI } from "plop";
 import path from "path";
 import { getTemplatesPath } from "./utils/paths.js";
+import { toPackageName } from "./utils/validation.js";
 
 interface PlopData {
   projectName: string;
@@ -261,12 +262,7 @@ export default function (plop: NodePlopAPI): void {
   });
 
   // Add helper functions for templates
-  plop.setHelper("kebabCase", (text: string) => {
-    return text
-      .replace(/([a-z])([A-Z])/g, "$1-$2")
-      .replace(/\s+/g, "-")
-      .toLowerCase();
-  });
+  plop.setHelper("kebabCase", (text: string) => toPackageName(text));
 
   plop.setHelper("camelCase", (text: string) => {
     return text

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,3 +1,25 @@
+/**
+ * The project name as it belongs in a package.json `name` field.
+ *
+ * npm has refused uppercase in new package names since 2017, so the directory
+ * the user typed cannot be reused verbatim. The directory keeps their casing;
+ * only the manifest field is normalised.
+ *
+ * Lives next to `validateProjectName` on purpose: that function has already
+ * restricted the input to `[a-zA-Z0-9_-]` starting with an alphanumeric by the
+ * time this runs, which is what makes lowercasing sufficient to produce a legal
+ * name. Loosen the charset there and this stops being enough.
+ *
+ * Both the Plop path (the `kebabCase` helper) and the ai-chat raw-copy path
+ * call this. They rendered the name separately before, and drifted.
+ */
+export function toPackageName(name: string): string {
+  return name
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .replace(/\s+/g, "-")
+    .toLowerCase();
+}
+
 export function validateProjectName(name: string): string | true {
   if (!name || name.trim().length === 0) {
     return 'Project name cannot be empty';

--- a/templates/base/package.json.hbs
+++ b/templates/base/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{projectName}}",
+  "name": "{{kebabCase projectName}}",
   "version": "0.1.0",
   "description": "{{description}}",
   "private": true,


### PR DESCRIPTION
Closes #412.

## 1. Unknown flag values were accepted

```
$ create app-bogus -t bogus --skip-install -y
→ succeeded, generated a bare base project
```

The string went straight into Plop, where every `{{#if (eq templateType "…")}}` is simply false, so the user got a project matching nothing in the docs and no indication anything was wrong.

Declared with commander's `.choices()` instead, which rejects before anything is written:

```
error: option '-t, --template <type>' argument 'bogus' is invalid.
       Allowed choices are basic, farcaster-miniapp, minipay, ai-chat.
error: option '--wallet-provider <provider>' argument 'nope' is invalid.
       Allowed choices are rainbowkit, thirdweb, none.
error: option '-c, --contracts <framework>' argument 'nope' is invalid.
       Allowed choices are hardhat, foundry, none.
```

No directory is created in any of those cases, and `-t minipay -c foundry` still scaffolds normally.

## 2. Uppercase names produced invalid npm manifests

`create MyApp` wrote `"name": "MyApp"` into `package.json`. npm refuses uppercase in new package names, so `npm pkg fix`, publishing, and some CI steps fail on a project the tool just generated.

Took the second option the issue offers — **lowercase the manifest field, keep the directory as typed** — because the directory name is the user's choice and not npm's business, and rejecting it outright would break anyone who wants `MyApp` as a folder. The `kebabCase` helper was already registered in `plopfile.ts`.

| `create …` | directory | manifest `name` |
|---|---|---|
| `MyApp` | `MyApp` | `my-app` |
| `my-app` | `my-app` | `my-app` |
| `celo-demo` | `celo-demo` | `celo-demo` |
| `app2` | `app2` | `app2` |

~~Only `templates/base/package.json.hbs` interpolates the project name into a `name` field, so that is the whole change.~~ **Wrong — corrected at `e1131c9`.** That was true of the `.hbs` files and false of the tool. `src/generators/plop-generator.ts` copies the ai-chat template verbatim and patches its `package.json` in JS, never reaching Plop, so the helper never ran there.

**The sweep, done properly this time, and reproducible:**

```bash
grep -rn '"name":.*projectName' templates/     # 1 hit  templates/base/package.json.hbs:2
grep -rn '\.name\s*=' src/ --include='*.ts'    # 1 hit  plop-generator.ts:64
find templates -name package.json               # 1 hit  ai/chat-template  <- the raw copy
```

Two write sites, not one, and the third command is the one that would have caught it: a template shipping a real `package.json` rather than a `.hbs` cannot be found by grepping for the interpolation.

## ⚠️ Merge-order dependency with #393

**#393 adds `x402` as a template type.** The choices list here does not include it, because on `main` that template does not exist — accepting `-t x402` today would produce exactly the silent bare project this PR removes.

So whichever lands second needs one line:

- **#412 first, then #393** → add `'x402'` to the `-t` choices in #393.
- **#393 first, then #412** → include `'x402'` in the list here before merging.

Flagging it because CI will not catch it: an omitted choice is a rejected flag, not a failing build. I will make the edit on whichever side is second as soon as the other lands.
