### PR TITLE
fix(templates): declare viem and wagmi once, not once per branch

### DIFF
--- a/templates/base/apps/web/package.json.hbs
+++ b/templates/base/apps/web/package.json.hbs
@@ -19,10 +19,10 @@
     "clsx": "^2.0.0",
     "tailwind-merge": "^2.0.0",
     "lucide-react": "^0.292.0"{{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb") (eq templateType "farcaster-miniapp"))}},
-    "@tanstack/react-query": "^5.64.2"{{/if}}{{#if (eq walletProvider "rainbowkit")}},
-    "@rainbow-me/rainbowkit": "^2.0.0",
-    "viem": "^2.0.0",
-    "wagmi": "^2.0.0"{{/if}}{{#if (eq walletProvider "thirdweb")}},
+    "@tanstack/react-query": "^5.64.2"{{/if}}{{#if (or (eq walletProvider "rainbowkit") (eq templateType "farcaster-miniapp"))}},
+    "viem": "^2.27.2",
+    "wagmi": "^2.14.12"{{/if}}{{#if (eq walletProvider "rainbowkit")}},
+    "@rainbow-me/rainbowkit": "^2.0.0"{{/if}}{{#if (eq walletProvider "thirdweb")}},
     "thirdweb": "^5.0.0"{{/if}}{{#if (eq templateType "farcaster-miniapp")}},
     "@farcaster/miniapp-sdk": "^0.3.0",
     "@farcaster/miniapp-core": "^0.6.0",
@@ -32,8 +32,6 @@
     "@t3-oss/env-nextjs": "^0.12.0",
     "eruda": "^3.2.3",
     "jose": "^5.9.6",
-    "viem": "^2.27.2",
-    "wagmi": "^2.14.12",
     "zod": "^3.24.1"{{/if}}
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #429.

`-t farcaster-miniapp --wallet-provider rainbowkit` renders both the wallet branch and the farcaster branch of `package.json.hbs`, and the two overlap on `viem` and `wagmi`. `JSON.parse` keeps the last occurrence, so the rainbowkit pins were silently discarded and nothing warned.

Hoisted both into a shared guard, at the stricter of the two ranges. Same treatment #428 gives `@tanstack/react-query`.

## Verified by generating, and by a control run

Duplicate keys are invisible to `JSON.parse`, so the check counts keys in the **raw text**:

| combination | `main` (control, `710dd89`) | this branch |
|---|---|---|
| `-t farcaster-miniapp --wallet-provider rainbowkit` | `viem×2 wagmi×2 @tanstack/react-query×2` | `@tanstack/react-query×2` only |
| `-t farcaster-miniapp` | none | none |
| `-t basic` (default rainbowkit) | none | none |
| `-t minipay` | none | none |
| `-t basic --wallet-provider thirdweb` | none | none |

`viem` and `wagmi` are still present in every combination that had them before, and still absent for thirdweb, which never declared them.

**The surviving `@tanstack/react-query×2` is #400, fixed by #428, not touched here.** It is worth leaving visible: it is also the positive control for the checker. A duplicate detector that reports "none" everywhere has not been shown to detect anything.

## On the version ranges

`^2.27.2` / `^2.14.12` are the farcaster branch's existing pins, kept because they are the stricter pair. Neither is stale:

- **viem** resolves to **2.55.13**, the current release. The caret floor only matters as a floor, and `@farcaster/miniapp-wagmi-connector@2.0.0` requires `viem: ^2.21.55`, which `^2.27.2` already clears.
- **wagmi stays on 2.x deliberately, though 3.7.6 exists.** Both wallet stacks this template ships require wagmi 2: the farcaster connector peers `@wagmi/core: ^2.14.1`, and `@rainbow-me/rainbowkit@2.2.11` peers `wagmi: ^2.9.0`. wagmi 3 ships `@wagmi/core@3.6.4`, so raising it here would break both. That is a separate upgrade with its own blast radius, not part of declaring a dependency once.

## Merge order

Both other open PRs touching this file were test-merged.

**#449 merges clean.** Different hunks — it edits the `@farcaster/*` lines.

**#428 conflicts**, because both rewrite the same five lines. It is mechanical: keep both guards, since they are not the same set — thirdweb needs `@tanstack/react-query` but not `viem`/`wagmi`. Whichever lands second wants this:

```hbs
    "lucide-react": "^0.292.0"{{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb") (eq templateType "farcaster-miniapp"))}},
    "@tanstack/react-query": "^5.64.2"{{/if}}{{#if (or (eq walletProvider "rainbowkit") (eq templateType "farcaster-miniapp"))}},
    "viem": "^2.27.2",
    "wagmi": "^2.14.12"{{/if}}{{#if (eq walletProvider "rainbowkit")}},
    "@rainbow-me/rainbowkit": "^2.0.0"{{/if}}{{#if (eq walletProvider "thirdweb")}},
```

Not proposed from reading the diff — all three were merged into one tree, resolved that way, and re-run. `tsc` clean, and the combination that started this issue generates with **no duplicate keys at all**, react-query included.
