### PR TITLE
fix(templates): make the ai-chat template build

### DIFF
--- a/templates/ai/chat-template/app/(chat)/layout.tsx
+++ b/templates/ai/chat-template/app/(chat)/layout.tsx
@@ -5,8 +5,6 @@ import { DataStreamProvider } from "@/components/data-stream-provider";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import Script from "next/script";
 
-export const experimental_ppr = true;
-
 export default async function Layout({
   children,
 }: {

--- a/templates/ai/chat-template/components/document-preview.tsx
+++ b/templates/ai/chat-template/components/document-preview.tsx
@@ -146,7 +146,7 @@ const PureHitboxLayer = ({
   result,
   setArtifact,
 }: {
-  hitboxRef: React.RefObject<HTMLDivElement>;
+  hitboxRef: React.RefObject<HTMLDivElement | null>;
   result: any;
   setArtifact: (
     updaterFn: UIArtifact | ((currentArtifact: UIArtifact) => UIArtifact),

--- a/templates/ai/chat-template/components/toolbar.tsx
+++ b/templates/ai/chat-template/components/toolbar.tsx
@@ -10,6 +10,7 @@ import {
   type Dispatch,
   memo,
   type ReactNode,
+  type RefObject,
   type SetStateAction,
   useEffect,
   useRef,
@@ -318,12 +319,16 @@ const PureToolbar = ({
   artifactKind: ArtifactKind;
 }) => {
   const toolbarRef = useRef<HTMLDivElement>(null);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const [selectedTool, setSelectedTool] = useState<string | null>(null);
   const [isAnimating, setIsAnimating] = useState(false);
 
-  useOnClickOutside(toolbarRef, () => {
+  // usehooks-ts 3.1.1 types this as RefObject<HTMLElement>, while React 19's
+  // useRef(null) produces RefObject<HTMLElement | null>. The hook guards
+  // `ref.current` before touching it, so the cast is accurate rather than a
+  // silenced null. Remove it if upstream widens the signature.
+  useOnClickOutside(toolbarRef as RefObject<HTMLDivElement>, () => {
     setIsToolbarVisible(false);
     setSelectedTool(null);
   });

--- a/templates/ai/chat-template/next.config.ts
+++ b/templates/ai/chat-template/next.config.ts
@@ -1,15 +1,32 @@
 import type { NextConfig } from 'next';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 const nextConfig: NextConfig = {
-  experimental: {
-    ppr: true,
-  },
   images: {
     remotePatterns: [
       {
         hostname: 'avatar.vercel.sh',
       },
     ],
+  },
+  webpack: (config) => {
+    const optionalPeers = [
+      '@x402/core',
+      '@x402/evm',
+      '@x402/extensions',
+      '@x402/svm',
+      '@react-native-async-storage/async-storage',
+    ];
+    for (const pkg of optionalPeers) {
+      try {
+        require.resolve(pkg);
+      } catch {
+        config.resolve.alias = { ...config.resolve.alias, [pkg]: false };
+      }
+    }
+    return config;
   },
 };
 


### PR DESCRIPTION
Refs #387 (the build half — the scaffolding half was #436).

The `experimental.ppr` blocker you found is real, and it was the first of four. Each one only became visible once the one before it was cleared, so the fix is a chain rather than a line.

## 1. `experimental.ppr` needs canary; the pin is stable

```
Error: The experimental feature "experimental.ppr" can only be enabled
       when using the latest canary version of Next.js.
```

Removed from `next.config.ts`. Also removed `export const experimental_ppr = true` from `app/(chat)/layout.tsx`, which is the route-level opt-in for the same feature — it does not error with PPR off, Next simply ignores it, so it would have sat there as dead config pointing at a flag the template no longer sets.

Removing rather than moving to canary, as you suggested: a template that only builds on a canary release is not a starter kit.

## 2. The `@x402` optional peers reach this template too

With PPR cleared, the build failed on five unresolved modules:

```
Can't resolve '@x402/core/client'
Can't resolve '@x402/evm'
Can't resolve '@x402/evm/exact/client'
Can't resolve '@x402/evm/upto/client'
Can't resolve '@x402/svm/exact/client'
```

Same defect as #398, reaching ai-chat by a different route — `thirdweb` → `@base-org/account` → `@coinbase/cdp-sdk`, which declares the `@x402` packages as optional peers and then imports them statically. #434 fixed this for `apps/web`; ai-chat has its own `next.config.ts` and never got it.

Applied the same `resolve.alias → false` loop, unchanged in behaviour: only packages that genuinely fail to resolve are stubbed, so installing them turns the stub off by itself. `createRequire(import.meta.url)` since this config is TypeScript rather than the base template's `.js`.

## 3 and 4. Two React 19 typing changes

The template pins `react: ^19.0.0`, and its types moved under it:

- `components/document-preview.tsx` — `useRef<HTMLDivElement>(null)` now yields `RefObject<HTMLDivElement | null>`, while the `hitboxRef` prop was declared `RefObject<HTMLDivElement>`. Widened the prop.
- `components/toolbar.tsx` — `useRef<ReturnType<typeof setTimeout>>()` no longer type-checks without an initial value, so it is `useRef<… | undefined>(undefined)`.

The second file also needed a cast at `useOnClickOutside(toolbarRef, …)`. **That one is not a version problem**: `usehooks-ts@3.1.1` is current and types the parameter `RefObject<T extends HTMLElement>`, with no nullable form, so no bump fixes it. Checked the implementation before casting rather than after — `index.js:535` reads `ref.current && !ref.current.contains(target)`, so it guards the null itself and the cast describes runtime behaviour instead of hiding a hazard. Noted at the call site with a line saying to drop it if upstream widens the signature.

## Verification

Generated a project from the template after the changes, not before:

```
$ celo-composer create fresh -t ai-chat -y --skip-install
$ pnpm install
$ npx tsc --noEmit          # 0 errors
$ npx next build            # exit 0
```

`next build` reaches the route table and exits 0. Note this is `next build` on its own — the package script is `tsx lib/db/migrate && next build`, and the migrate step needs a real `POSTGRES_URL`, which is the separate documented requirement rather than a template defect.

**What is not fixed here:** the deployability items in #387 beyond the build itself. This closes the "does it compile" half; if the issue is tracking more than that, happy to leave it open and retitle.
