### PR TITLE
fix(templates): wire the farcaster connect button, and match the real connector id

### DIFF
--- a/templates/base/apps/web/src/components/navbar.tsx.hbs
+++ b/templates/base/apps/web/src/components/navbar.tsx.hbs
@@ -11,7 +11,7 @@ import {
   SheetContent,
   SheetTrigger,
 } from "@/components/ui/sheet"
-{{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb"))}}
+{{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb") (eq templateType "farcaster-miniapp"))}}
 import { WalletConnectButton } from "@/components/connect-button"
 {{/if}}
 
@@ -58,7 +58,7 @@ export function Navbar() {
                   </Link>
                 ))}
                 <div className="mt-6 pt-6 border-t">
-                  {{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb"))}}
+                  {{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb") (eq templateType "farcaster-miniapp"))}}
                     {{#if (eq templateType 'minipay')}}
                   <Button asChild className="w-full">
                     <WalletConnectButton />
@@ -103,7 +103,7 @@ export function Navbar() {
           ))}
           
           <div className="flex items-center gap-3">
-            {{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb"))}}
+            {{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb") (eq templateType "farcaster-miniapp"))}}
             <WalletConnectButton />
             {{else}}
             <Button variant="outline" size="sm">Connect Wallet</Button>

--- a/templates/farcaster-miniapp/apps/web/src/components/connect-button.tsx.hbs
+++ b/templates/farcaster-miniapp/apps/web/src/components/connect-button.tsx.hbs
@@ -24,11 +24,17 @@ export function WalletConnectButton() {
   }
 
   if (!isConnected) {
-    const frameConnector = connectors.find(connector => connector.id === 'frameWallet')
-    
+    // The connector registers as id 'farcaster' (name 'Farcaster'). The string
+    // 'frameWallet' appears nowhere in @farcaster/miniapp-wagmi-connector — it
+    // is left over from the Frames-era connector — so the lookup returned
+    // undefined and the button rendered and did nothing. app/page.tsx already
+    // matched on 'farcaster'; the two files disagreed.
+    const farcasterConnector = connectors.find(connector => connector.id === 'farcaster')
+
     return (
       <button
-        onClick={() => frameConnector && connect({ connector: frameConnector })}
+        onClick={() => farcasterConnector && connect({ connector: farcasterConnector })}
+        disabled={!farcasterConnector}
         type="button"
         className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2"
       >


### PR DESCRIPTION
Closes #403. Two independent faults, and either one alone would have left the flow dead.

## 1. The component was never rendered

`navbar.tsx.hbs` guarded the import and both render sites on the wallet provider:

```hbs
{{#if (or (eq walletProvider "rainbowkit") (eq walletProvider "thirdweb"))}}
```

`create.ts` forces `walletProvider` to `"none"` for farcaster, so all three guards were false and the navbar fell through to `<Button>Connect Wallet</Button>` with no `onClick`. The template shipped a working `WalletConnectButton` that nothing imported.

Widened all three to include `templateType === "farcaster-miniapp"`. The farcaster template writes its own `connect-button.tsx` to `apps/web/src/components/`, which is exactly the path the navbar imports, and it exports the same `WalletConnectButton` name — so the wiring already matched, it was only gated off.

## 2. The lookup used an id that does not exist

```ts
const frameConnector = connectors.find(connector => connector.id === 'frameWallet')
```

Checked the package rather than the issue text. `@farcaster/miniapp-wagmi-connector@2.0.0`, `dist/connector.js:18-19`:

```js
id: 'farcaster',
name: 'Farcaster',
```

**`frameWallet` appears nowhere in the package** — not as an id, not as a type. `grep -rn frameWallet node_modules/@farcaster/miniapp-wagmi-connector/dist/` returns nothing. It reads like a leftover from the Frames-era connector, which fits the half-migrated SDK layer #405 described.

So the lookup returned `undefined` and `frameConnector && connect(...)` was a no-op. `app/page.tsx:35` was already matching on `'farcaster'` — the two files in the same template disagreed, and the one users click was the wrong one.

Also added `disabled={!farcasterConnector}`, so if the connector is genuinely absent the button is visibly unavailable rather than looking live and doing nothing. That was the actual user-facing symptom.

## Verification

Generated projects rather than reading the diff:

| | result |
|---|---|
| farcaster navbar | imports `WalletConnectButton` at line 14, renders it at 59 and 94 |
| farcaster connect-button | `connector.id === 'farcaster'` |
| basic, minipay navbars | unchanged, 3 references each |
| parse errors, all three | 0 |
| JSX rendered but never bound, all three | none |
| CLI suite | 15/15 |

The last two rows matter because #396 was the mirror image of this bug — a navbar rendering a component nothing wrote. The check that catches that now runs against farcaster too and is clean.

**Not covered:** no real connection was made inside a Farcaster client. That needs a published manifest on a public domain and the app opened in the Farcaster browser. What is verified is that the button is rendered, the connector id matches the package, and nothing else regressed.
