### PR TITLE
fix(templates): drop the farcaster eslint overrides that never resolved

### DIFF
--- a/src/plopfile.ts
+++ b/src/plopfile.ts
@@ -204,28 +204,11 @@ export default function (plop: NodePlopAPI): void {
         },
         verbose: true,
       },
-      // Conditionally add Farcaster Miniapp configuration files
-      {
-        type: "addMany",
-        destination: "{{projectPath}}/apps/web/",
-        base: path.join(templatesPath, "farcaster-miniapp/apps/web/"),
-        templateFiles: [
-          path.join(templatesPath, "farcaster-miniapp/apps/web/.eslintrc.json.hbs")
-        ],
-        globOptions: {
-          dot: true,
-        },
-        // The base template now ships an .eslintrc.json of its own, so this has to
-        // overwrite it rather than silently lose the Farcaster rule overrides.
-        force: true,
-        skip: (data: PlopData): string | false => {
-          if (data.templateType !== "farcaster-miniapp") {
-            return "Skipping Farcaster Miniapp config - different template type selected";
-          }
-          return false;
-        },
-        verbose: true,
-      },
+      // Farcaster used to overwrite the base .eslintrc.json here, purely to keep
+      // three @typescript-eslint rule overrides. Those rules never resolved, so
+      // the overwrite existed to preserve a broken config — see #402. The base
+      // config is written for every template and is what farcaster needs, so
+      // both the file and this action are gone.
       // Add Farcaster setup documentation
       {
         type: "add",

--- a/templates/farcaster-miniapp/apps/web/.eslintrc.json.hbs
+++ b/templates/farcaster-miniapp/apps/web/.eslintrc.json.hbs
@@ -1,8 +1,0 @@
-{
-  "extends": "next/core-web-vitals",
-  "rules": {
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-unused-vars": "warn"
-  }
-}


### PR DESCRIPTION
Closes #402.

Reproduced first: a fresh `-t farcaster-miniapp` scaffold compiles, then fails the lint step on **all 22 TypeScript files** with `Definition for rule '@typescript-eslint/no-unused-vars' was not found`.

## Why the plugin is missing, which is not what the issue assumed

The issue suggests adding `@typescript-eslint/eslint-plugin` to the farcaster dependency branch. Worth recording that it is already there, one level down:

```
$ ls node_modules/.pnpm | grep typescript-eslint
@typescript-eslint+eslint-plugin@8.67.0_…
@typescript-eslint+parser@8.67.0_…
```

`eslint-config-next@14` depends on both. **pnpm does not hoist transitive dependencies**, so they sit in `.pnpm/` and never appear in `apps/web/node_modules/`, which is where ESLint resolves plugin names from. Declaring the plugin directly would work by giving pnpm a reason to link it — the fix in the issue is sound, the stated cause is not.

## Took the other option, and here is the argument

Two of the three overrides turn **off** rules that `next/core-web-vitals` never turns on, so they are no-ops. The third is a `warn`, which does not gate a build. Since none of them resolved, nothing they were meant to do has ever happened — dropping them loses no behaviour that currently works, while declaring the plugin would add a dependency to every farcaster scaffold to restore one warning.

After dropping the rules the file was **byte-identical to the base config**. That made a second thing visible: `plopfile.ts` carried a `force: true` action whose only job was to overwrite the base `.eslintrc.json` with this one, with a comment saying it existed so the Farcaster rule overrides were not silently lost. It was overwriting a working config with a broken one.

So the file and that action are both gone. The base `.eslintrc.json` is written for every template — that copy action has no `skip` — so farcaster now gets the same config as everything else.

## Verification

| | before | after |
|---|---|---|
| farcaster `pnpm build` | **fails**, 22 rule-not-found errors | **exit 0** |
| farcaster `.eslintrc.json` | 3 unresolvable rules | `{ "extends": "next/core-web-vitals" }` |
| basic / minipay `.eslintrc.json` | unchanged | unchanged |
| CLI suite | — | 15/15 |

The only lint output left on a farcaster scaffold is one pre-existing warning about `<img>` versus `next/image` in `page.tsx`, which is a warning and does not fail the build. Not touched here — it is a template quality question rather than this bug, and worth its own issue if you want it addressed.

Checked the other template that ships its own ESLint config, `templates/ai/chat-template/.eslintrc.json`: it uses `tailwindcss`, `import` and `prettier`, all declared in its own `package.json`, and it builds clean. This was farcaster-only.
