### PR TITLE
fix(templates): keep the thirdweb scaffold building without a client id

### DIFF
--- a/templates/wallets/thirdweb/lib/client.ts.hbs
+++ b/templates/wallets/thirdweb/lib/client.ts.hbs
@@ -1,12 +1,23 @@
 import { createThirdwebClient } from "thirdweb";
 
-// Replace this with your client ID get one from https://thirdweb.com/dashboard/
-const clientId = process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID!;
+// Get a client ID from https://thirdweb.com/dashboard and set it in
+// apps/web/.env as NEXT_PUBLIC_THIRDWEB_CLIENT_ID.
+//
+// This falls back to a placeholder rather than throwing. The page tree imports
+// this module, so a throw here runs during the prerender step of `next build`
+// and makes a fresh scaffold fail before anyone has had a chance to configure
+// anything. `createThirdwebClient` accepts any non-empty string without
+// validating it, so the build stays green and the failure lands where it means
+// something — the first call that actually needs the ID.
+const clientId = process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID;
 
 if (!clientId) {
-  throw new Error("Missing NEXT_PUBLIC_THIRDWEB_CLIENT_ID environment variable");
+  console.warn(
+    "[thirdweb] NEXT_PUBLIC_THIRDWEB_CLIENT_ID is not set, using a placeholder. " +
+      "Wallet connection will not work until you set it in apps/web/.env."
+  );
 }
 
 export const client = createThirdwebClient({
-  clientId,
+  clientId: clientId || "YOUR_CLIENT_ID",
 });


### PR DESCRIPTION
Closes #452.

Reproduced exactly as described: a fresh `-t basic --wallet-provider thirdweb -c none` scaffold compiles, then fails prerendering `/` and `/_not-found` with `Missing NEXT_PUBLIC_THIRDWEB_CLIENT_ID environment variable`.

## The fix, and the claim it rests on

Took the placeholder route you suggested, matching what rainbowkit already does with `|| 'YOUR_PROJECT_ID'`.

That only works if thirdweb really does not validate the id at construction, so I checked rather than assuming — running against the installed `thirdweb` in a generated project:

| `clientId` | result |
|---|---|
| `"YOUR_CLIENT_ID"` | client created |
| `"placeholder"` | client created |
| `"x"` | client created |
| `""` | **throws** `clientId or secretKey must be provided` |

So any non-empty string is accepted and only the empty string is rejected — the placeholder is safe, and `|| "YOUR_CLIENT_ID"` can never produce the empty case.

## Added a warning as well as the fallback

Your issue offered "placeholder **or** runtime check with a console warning". I took both, because the placeholder alone trades one bad failure for another: the build goes green, the developer deploys, and thirdweb then fails on an authenticated call with an error that never mentions the missing variable.

```
[thirdweb] NEXT_PUBLIC_THIRDWEB_CLIENT_ID is not set, using a placeholder.
Wallet connection will not work until you set it in apps/web/.env.
```

It fires during the build too, since prerendering evaluates the module — which is the right moment to see it.

## Verification

| | result |
|---|---|
| `pnpm build`, no env set | **exit 0**, compiles, warning printed |
| `pnpm build`, `NEXT_PUBLIC_THIRDWEB_CLIENT_ID` set | exit 0, **no warning** |
| CLI suite | 15/15 |

The second row is the one that matters for regression: the fallback and the warning both stay out of the way when the variable is present.

One thing left alone, and worth flagging rather than fixing quietly: `.env.template` ships `NEXT_PUBLIC_THIRDWEB_CLIENT_ID=your_client_id_here`. A developer who copies that file without editing it gets a non-empty value, so no warning fires and the placeholder path is never taken — they reach the same authenticated-call failure with no hint. Rainbowkit's `your_project_id_here` has the identical shape. That is a wider question about whether the env templates should ship empty values rather than filled placeholders, so it did not belong in this fix.
