### PR TITLE
docs(foundry): commands that run, and the aliases that exist

### DIFF
--- a/docs/integrations/contracts/foundry.mdx
+++ b/docs/integrations/contracts/foundry.mdx
@@ -28,34 +28,56 @@ The template comes with the following features and configurations out of the box
 - **Deployment Scripts**: A `Counter.s.sol` script for deploying your contract using `forge script`.
 - **Tests**: A `Counter.t.sol` test file with examples of how to write tests for your contract using `forge test`.
 - **`.env.example`**: A template for your environment variables, including `PRIVATE_KEY` and `ETHERSCAN_API_KEY`.
+- **`remappings.txt`** and a **`package.json`**, so the workspace picks the project up and the root `contracts:*` scripts reach it.
+- **`README.md`** inside `apps/contracts` with the same commands, plus the network table and faucet link.
 
 ## Key Commands
 
-All commands should be run from the `apps/contracts` directory.
-
-### Compile Contracts
+Run these from the project root:
 
 ```bash
-forge build
+pnpm contracts:compile             # forge build
+pnpm contracts:test                # forge test
+pnpm contracts:deploy:celo-sepolia
+pnpm contracts:deploy:celo
 ```
 
-### Run Tests
-
-```bash
-forge test
-```
+Or run `forge` directly from `apps/contracts`.
 
 ### Deploy Contract
 
-To deploy to a specific network, you'll need to have your `PRIVATE_KEY` set in a `.env` file.
+Copy `.env.example` to `.env` and fill in `PRIVATE_KEY` first.
+
+The network names come from the `[rpc_endpoints]` block in `foundry.toml`, which defines **`celo-sepolia`** and **`celo`**. There is no `mainnet` alias.
 
 ```bash
-# Deploy to Celo Sepolia
-forge script script/Counter.s.sol:CounterScript --rpc-url --chain-id --broadcast --verify
+cd apps/contracts
+source .env
 
-# Deploy to Celo Mainnet
-forge script script/Counter.s.sol:CounterScript --rpc-url mainnet --broadcast --verify
+# Celo Sepolia
+forge script script/Counter.s.sol:CounterScript \
+  --rpc-url celo-sepolia \
+  --private-key $PRIVATE_KEY \
+  --broadcast
+
+# Celo Mainnet
+forge script script/Counter.s.sol:CounterScript \
+  --rpc-url celo \
+  --private-key $PRIVATE_KEY \
+  --broadcast
 ```
+
+`Counter.s.sol` calls `vm.startBroadcast()` with no arguments, so the key comes from the command line rather than from the script — which is why `--private-key` is needed even with `PRIVATE_KEY` in the environment.
+
+For an account holding real funds, use a keystore instead of a raw key:
+
+```bash
+cast wallet import deployer --interactive
+forge script script/Counter.s.sol:CounterScript \
+  --rpc-url celo --account deployer --broadcast
+```
+
+To verify on Celoscan, add `--verify --etherscan-api-key $ETHERSCAN_API_KEY`.
 
 ### Local Development with Anvil
 


### PR DESCRIPTION
Closes #419.

Two of the four items in the issue had already been fixed by #430 and #443 landing. Re-checked each against a generated project rather than working from the issue text.

| issue item | state now |
|---|---|
| 1. `.env.example` does not exist | **already fixed** — #430 generates it, with `PRIVATE_KEY` and `ETHERSCAN_API_KEY`, so the page's claim is now true |
| 2. Deploy command has empty `--rpc-url` and `--chain-id` | still broken, fixed here |
| 3. `--rpc-url mainnet` is not a defined alias | still broken, fixed here |
| 4. Page points at `packages/contracts` | **already fixed** — lines 20 and 34 read `apps/contracts` |

## The alias, demonstrated

`foundry.toml` defines exactly two:

```toml
[rpc_endpoints]
celo-sepolia = "https://forno.celo-sepolia.celo-testnet.org/"
celo = "https://forno.celo.org"
```

There is no `mainnet`, and foundry does not fail with a helpful message — it falls back to treating the value as a path:

```
$ forge script script/Counter.s.sol:CounterScript --rpc-url mainnet
Error: Internal transport error: No such file or directory (os error 2)
       with /…/apps/contracts/mainnet
```

## What the section says now

Rewritten around the two real aliases, and deliberately **matched to the README that #430 now ships inside `apps/contracts`** rather than inventing a third phrasing for the same commands. Same deploy form, same keystore alternative.

Added one thing the page never explained: `--private-key` is needed even with `PRIVATE_KEY` exported, because `Counter.s.sol` calls `vm.startBroadcast()` with no arguments, so the key comes from the command line rather than from the script. That is the detail that makes the documented command reproducible instead of nearly right.

Also added the root `contracts:*` scripts, which #430 introduced and this page did not mention at all, and two files to the "What's Included" list that the template now generates — `remappings.txt` and `package.json`.

## Verification

Generated `-t basic -c foundry` and ran what the page now claims:

```
$ forge build
Compiling 23 files with Solc 0.8.30
Compiler run successful!

$ forge test
Suite result: ok. 2 passed; 0 failed; 0 skipped

$ forge script script/Counter.s.sol:CounterScript --rpc-url celo-sepolia
Transactions saved to: …/broadcast/Counter.s.sol/11142220/dry-run/run-latest.json
```

The chain id in that path is **11142220**, which is Celo Sepolia — so the alias resolves and reaches the intended network, not just parses.

The four root scripts exist in the generated `package.json`. I did not run them end to end because that needs a full install for `turbo`; what they wrap is the `forge` invocations above.

No broadcast was performed, so nothing was deployed. The dry run is as far as verification goes without funding a key.
