### PR TITLE
fix(cli): stop an explicit --wallet-provider being discarded in silence

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -6,6 +6,10 @@ import ora from "ora";
 import path from "path";
 import { generateProject } from "../generators/project-generator.js";
 import { validateProjectName } from "../utils/validation.js";
+import {
+  ignoresWalletProvider,
+  walletOverrideReason,
+} from "../utils/templates.js";
 
 interface CreateOptions {
   description?: string;
@@ -67,16 +71,11 @@ export async function createCommand(
             const autoTemplateType =
               cliTemplateType || "basic";
             // FORCED, not defaulted. The plopfile guards skip the wallet
-            // components for these template types unconditionally, so a flag
-            // saying otherwise cannot be honoured — it just produces a navbar
-            // importing a connect-button nothing writes. Farcaster and Minipay
-            // survive that because they ship their own replacement; x402 and
-            // ai-chat ship none, which is where it fails silently.
-            const scaffoldsOwnWallet =
-              autoTemplateType === "farcaster-miniapp" ||
-              autoTemplateType === "ai-chat" ||
-              autoTemplateType === "x402";
-            const autoWallet = scaffoldsOwnWallet
+            // actions for these template types unconditionally, so a flag
+            // saying otherwise cannot be honoured. The list and the two
+            // distinct reasons live in utils/templates.ts — they used to be
+            // restated here and in the skip strings, and had drifted.
+            const autoWallet = ignoresWalletProvider(autoTemplateType)
               ? "none"
               : options.walletProvider ?? "rainbowkit";
             // NOT forced, unlike the wallet above — the two guards are not
@@ -264,17 +263,28 @@ export async function createCommand(
     // Forced here, and it has to be HERE. Computing it in the auto-mode branch
     // above is not enough — this is the value that reaches plop, and it read
     // `options.walletProvider` first, so an explicit flag won again regardless.
-    //
-    // plopfile.ts skips the rainbowkit and thirdweb component actions for these
-    // template types unconditionally, so the flag cannot be honoured; it only
-    // produces a navbar importing a component nothing writes. Farcaster and
-    // Minipay ship their own replacement, x402 and ai-chat ship none.
-    const finalWalletProvider =
-      finalTemplateType === "farcaster-miniapp" ||
-      finalTemplateType === "ai-chat" ||
-      finalTemplateType === "x402"
-        ? "none"
-        : options.walletProvider || answers.walletProvider || "rainbowkit";
+    const finalWalletProvider = ignoresWalletProvider(finalTemplateType)
+      ? "none"
+      : options.walletProvider || answers.walletProvider || "rainbowkit";
+
+    // The flag was passed and then dropped, so say so. Until now `create app
+    // -t x402 --wallet-provider thirdweb` exited 0 having produced a project
+    // with no thirdweb in it, and nothing told the user their flag did
+    // nothing. `--wallet-provider none` is what the forcing does anyway, so
+    // it is agreement rather than a conflict and stays quiet.
+    if (
+      options.walletProvider &&
+      options.walletProvider !== "none" &&
+      finalWalletProvider === "none"
+    ) {
+      console.warn(
+        chalk.yellow(
+          `⚠️  Ignoring --wallet-provider ${options.walletProvider}: ${walletOverrideReason(
+            finalTemplateType
+          )}.`
+        )
+      );
+    }
     let finalContractFramework = options.contracts || answers.contractFramework;
     if (!finalContractFramework) {
       finalContractFramework =

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -7,7 +7,7 @@ import path from "path";
 import { generateProject } from "../generators/project-generator.js";
 import { validateProjectName } from "../utils/validation.js";
 import {
-  ignoresWalletProvider,
+  forcedWalletProvider,
   walletOverrideReason,
 } from "../utils/templates.js";
 
@@ -75,9 +75,10 @@ export async function createCommand(
             // saying otherwise cannot be honoured. The list and the two
             // distinct reasons live in utils/templates.ts — they used to be
             // restated here and in the skip strings, and had drifted.
-            const autoWallet = ignoresWalletProvider(autoTemplateType)
-              ? "none"
-              : options.walletProvider ?? "rainbowkit";
+            const autoWallet =
+              forcedWalletProvider(autoTemplateType) ??
+              options.walletProvider ??
+              "rainbowkit";
             // NOT forced, unlike the wallet above — the two guards are not
             // symmetric. The wallet actions in plopfile.ts check the template
             // type as well ("This template uses its own wallet components"),
@@ -263,25 +264,33 @@ export async function createCommand(
     // Forced here, and it has to be HERE. Computing it in the auto-mode branch
     // above is not enough — this is the value that reaches plop, and it read
     // `options.walletProvider` first, so an explicit flag won again regardless.
-    const finalWalletProvider = ignoresWalletProvider(finalTemplateType)
-      ? "none"
-      : options.walletProvider || answers.walletProvider || "rainbowkit";
+    // NOT always "none". minipay is forced to rainbowkit, because its own
+    // components import RainbowKitProvider/WagmiProvider and the base manifest
+    // gates those packages on this value — forcing "none" shipped a scaffold
+    // with the components and none of what they import. See utils/templates.ts.
+    const forcedWallet = forcedWalletProvider(finalTemplateType);
+    const finalWalletProvider =
+      forcedWallet ?? (options.walletProvider || answers.walletProvider || "rainbowkit");
 
     // The flag was passed and then dropped, so say so. Until now `create app
     // -t x402 --wallet-provider thirdweb` exited 0 having produced a project
     // with no thirdweb in it, and nothing told the user their flag did
     // nothing. `--wallet-provider none` is what the forcing does anyway, so
     // it is agreement rather than a conflict and stays quiet.
+    // Warn when the flag was passed and does not survive — whatever it was
+    // overridden TO. A flag that agrees with the forced value (`--wallet-provider
+    // rainbowkit` on minipay, or `none` on x402) is agreement, not a conflict,
+    // and stays quiet.
     if (
       options.walletProvider &&
-      options.walletProvider !== "none" &&
-      finalWalletProvider === "none"
+      forcedWallet !== null &&
+      options.walletProvider !== forcedWallet
     ) {
       console.warn(
         chalk.yellow(
           `⚠️  Ignoring --wallet-provider ${options.walletProvider}: ${walletOverrideReason(
             finalTemplateType
-          )}.`
+          )}. Using ${forcedWallet} instead.`
         )
       );
     }

--- a/src/generators/template-wiring.test.ts
+++ b/src/generators/template-wiring.test.ts
@@ -215,8 +215,54 @@ describe("an explicit --wallet-provider the template cannot honour", () => {
     // had it.
     expect(fs.pathExistsSync(path.join(projectPath, "apps/web/src/lib/client.ts"))).toBe(false);
 
+    // minipay is forced to rainbowkit rather than to "none", so the packages its
+    // own components import are still declared. The first version of this fix
+    // forced "none" and shipped a scaffold with the components and none of what
+    // they import — see the minipay default test below.
+    const pkg = fs.readJsonSync(path.join(projectPath, "apps/web/package.json"));
+    expect(pkg.dependencies).toHaveProperty("@rainbow-me/rainbowkit");
+    expect(pkg.dependencies).toHaveProperty("wagmi");
+
     expect(stderr).toContain("Ignoring --wallet-provider thirdweb");
-    expect(stderr).toContain("ships its own wallet components");
+    expect(stderr).toContain("rainbowkit-based wallet components");
+    expect(stderr).toContain("Using rainbowkit instead");
+  });
+
+  it("a default minipay scaffold keeps the stack its components import", () => {
+    // The assertion that was missing, and the one that catches the regression
+    // review found on #461: minipay's wallet-provider.tsx imports
+    // RainbowKitProvider, WagmiProvider and QueryClientProvider, and
+    // user-balance.tsx uses wagmi hooks. The base manifest gates all four
+    // packages on walletProvider === "rainbowkit", so forcing "none" produced a
+    // project whose own components import packages it does not declare.
+    //
+    // No flag at all: this is what every ordinary minipay user gets.
+    const { projectPath } = keep(generateWith("minipay", "mp-default"));
+    const pkg = fs.readJsonSync(path.join(projectPath, "apps/web/package.json"));
+
+    for (const dep of [
+      "@rainbow-me/rainbowkit",
+      "wagmi",
+      "viem",
+      "@tanstack/react-query",
+    ]) {
+      expect(pkg.dependencies).toHaveProperty(dep);
+    }
+
+    // And the components that need them are actually there.
+    const components = fs.readdirSync(path.join(projectPath, "apps/web/src/components"));
+    expect(components).toEqual(
+      expect.arrayContaining(["connect-button.tsx", "wallet-provider.tsx", "user-balance.tsx"])
+    );
+  });
+
+  it("stays quiet when the flag names the provider the template requires", () => {
+    // `--wallet-provider rainbowkit` on minipay is agreement, not a conflict —
+    // the same case as `--wallet-provider none` on x402 below.
+    const { stderr } = keep(
+      generateWith("minipay", "mp-agrees", ["--wallet-provider", "rainbowkit"])
+    );
+    expect(stderr).not.toContain("Ignoring --wallet-provider");
   });
 
   it("gives the other reason for a template that ships no wallet layer", () => {

--- a/src/generators/template-wiring.test.ts
+++ b/src/generators/template-wiring.test.ts
@@ -9,12 +9,17 @@
  * so they fail on a missed edit rather than on a changed line number.
  */
 
-import { execFileSync } from "child_process";
+import { spawnSync } from "child_process";
 import fs from "fs-extra";
 import os from "os";
 import path from "path";
 
 const repoRoot = path.resolve(__dirname, "..", "..");
+
+interface Generated {
+  projectPath: string;
+  stderr: string;
+}
 
 /**
  * Drive the CLI the way a user does, as a subprocess, rather than importing the
@@ -22,9 +27,15 @@ const repoRoot = path.resolve(__dirname, "..", "..");
  * ESM-only, which Jest cannot load in-process without switching the whole runner
  * over. Running it through `tsx` sidesteps that and tests the real entry point.
  */
-function generate(templateType: string, name: string): string {
+function generateWith(
+  templateType: string,
+  name: string,
+  extraArgs: string[] = []
+): Generated {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "composer-test-"));
-  execFileSync(
+  // spawnSync rather than execFileSync: a diagnostic printed to stderr is part
+  // of what these tests assert on, and execFileSync only hands back stdout.
+  const run = spawnSync(
     path.join(repoRoot, "node_modules", ".bin", "tsx"),
     [
       path.join(repoRoot, "src", "index.ts"),
@@ -32,6 +43,7 @@ function generate(templateType: string, name: string): string {
       name,
       "-t",
       templateType,
+      ...extraArgs,
       "--skip-install",
       // -y, because a flag no longer implies it. #411 makes only -y skip the
       // prompts, so without this the fixture blocks on an interactive question
@@ -39,9 +51,18 @@ function generate(templateType: string, name: string): string {
       // lands, required after.
       "-y",
     ],
-    { cwd: root, stdio: "pipe" }
+    { cwd: root, encoding: "utf8" }
   );
-  return path.join(root, name);
+  if (run.status !== 0) {
+    throw new Error(
+      `create -t ${templateType} ${extraArgs.join(" ")} exited ${run.status}\n${run.stderr}`
+    );
+  }
+  return { projectPath: path.join(root, name), stderr: run.stderr };
+}
+
+function generate(templateType: string, name: string): string {
+  return generateWith(templateType, name).projectPath;
 }
 
 // Generating a project shells out to git; give it room.
@@ -150,5 +171,86 @@ describe("other templates are unaffected", () => {
   it("does not leak the pnpm peer exemption into a basic project", () => {
     const pkg = fs.readJsonSync(path.join(projectPath, "package.json"));
     expect(pkg.pnpm).toBeUndefined();
+  });
+});
+
+/**
+ * Four templates cannot honour `--wallet-provider`, for two different reasons,
+ * and one of them was not cosmetic. minipay writes `connect-button.tsx` and
+ * `wallet-provider.tsx`, the same two filenames the thirdweb template writes,
+ * and nothing stopped both actions from running: `-t minipay --wallet-provider
+ * thirdweb` aborted with "File already exists", exited 1, and left a project
+ * half on disk. The other three discarded the flag in silence.
+ */
+describe("an explicit --wallet-provider the template cannot honour", () => {
+  const roots: string[] = [];
+  const keep = (g: Generated): Generated => {
+    roots.push(path.dirname(g.projectPath));
+    return g;
+  };
+
+  afterAll(() => {
+    for (const root of roots) fs.removeSync(root);
+  });
+
+  it("does not collide with minipay's own components, and says why", () => {
+    // The regression. Before this, generateWith threw here on exit 1.
+    const { projectPath, stderr } = keep(
+      generateWith("minipay", "mp-fixture", ["--wallet-provider", "thirdweb"])
+    );
+
+    const components = fs.readdirSync(
+      path.join(projectPath, "apps/web/src/components")
+    );
+    // minipay's own three survive...
+    expect(components).toEqual(
+      expect.arrayContaining([
+        "connect-button.tsx",
+        "wallet-provider.tsx",
+        "user-balance.tsx",
+      ])
+    );
+    // ...and thirdweb's lib never lands beside them. This is the half of the
+    // guard that was missing on the lib action while the components action
+    // had it.
+    expect(fs.pathExistsSync(path.join(projectPath, "apps/web/src/lib/client.ts"))).toBe(false);
+
+    expect(stderr).toContain("Ignoring --wallet-provider thirdweb");
+    expect(stderr).toContain("ships its own wallet components");
+  });
+
+  it("gives the other reason for a template that ships no wallet layer", () => {
+    const { projectPath, stderr } = keep(
+      generateWith("x402", "x402-wallet-fixture", [
+        "--wallet-provider",
+        "thirdweb",
+      ])
+    );
+    // x402 ships none, so the message must not claim it has its own.
+    expect(stderr).toContain("ships no wallet layer of its own");
+    expect(stderr).not.toContain("ships its own wallet components");
+    expect(fs.pathExistsSync(path.join(projectPath, "apps/web/src/lib/client.ts"))).toBe(false);
+  });
+
+  it("stays quiet when the flag agrees with the forcing", () => {
+    // `--wallet-provider none` is what the template gets anyway. Warning there
+    // would be noise about a conflict that does not exist.
+    const { stderr } = keep(
+      generateWith("x402", "x402-none-fixture", ["--wallet-provider", "none"])
+    );
+    expect(stderr).not.toContain("Ignoring --wallet-provider");
+  });
+
+  it("still wires thirdweb for a template that can take it", () => {
+    // The control. A guard that suppresses everything would pass every
+    // assertion above.
+    const { projectPath, stderr } = keep(
+      generateWith("basic", "basic-thirdweb-fixture", [
+        "--wallet-provider",
+        "thirdweb",
+      ])
+    );
+    expect(fs.pathExistsSync(path.join(projectPath, "apps/web/src/lib/client.ts"))).toBe(true);
+    expect(stderr).not.toContain("Ignoring --wallet-provider");
   });
 });

--- a/src/plopfile.ts
+++ b/src/plopfile.ts
@@ -2,7 +2,7 @@ import type { NodePlopAPI } from "plop";
 import path from "path";
 import { getTemplatesPath } from "./utils/paths.js";
 import { toPackageName } from "./utils/validation.js";
-import { ignoresWalletProvider, walletSkipReason } from "./utils/templates.js";
+import { skipsWalletTemplateFiles, walletSkipReason } from "./utils/templates.js";
 
 interface PlopData {
   projectName: string;
@@ -75,7 +75,7 @@ export default function (plop: NodePlopAPI): void {
         base: path.join(templatesPath, "wallets/rainbowkit/components/"),
         templateFiles: path.join(templatesPath, "wallets/rainbowkit/components/*.tsx.hbs"),
         skip: (data: PlopData): string | false => {
-          if (ignoresWalletProvider(data.templateType)) {
+          if (skipsWalletTemplateFiles(data.templateType)) {
             return walletSkipReason("RainbowKit", data.templateType);
           }
           if (data.walletProvider !== "rainbowkit") {
@@ -123,7 +123,7 @@ export default function (plop: NodePlopAPI): void {
         base: path.join(templatesPath, "wallets/thirdweb/components/"),
         templateFiles: path.join(templatesPath, "wallets/thirdweb/components/*.tsx.hbs"),
         skip: (data: PlopData): string | false => {
-          if (ignoresWalletProvider(data.templateType)) {
+          if (skipsWalletTemplateFiles(data.templateType)) {
             return walletSkipReason("Thirdweb", data.templateType);
           }
           if (data.walletProvider !== "thirdweb") {
@@ -143,7 +143,7 @@ export default function (plop: NodePlopAPI): void {
           // Same guard as the components action above. It was narrower than
           // that one, which was harmless only because walletProvider is forced
           // to "none" for the templates it missed — a latent copy of #396.
-          if (ignoresWalletProvider(data.templateType)) {
+          if (skipsWalletTemplateFiles(data.templateType)) {
             return walletSkipReason("Thirdweb lib", data.templateType);
           }
           if (data.walletProvider !== "thirdweb") {

--- a/src/plopfile.ts
+++ b/src/plopfile.ts
@@ -2,6 +2,7 @@ import type { NodePlopAPI } from "plop";
 import path from "path";
 import { getTemplatesPath } from "./utils/paths.js";
 import { toPackageName } from "./utils/validation.js";
+import { ignoresWalletProvider, walletSkipReason } from "./utils/templates.js";
 
 interface PlopData {
   projectName: string;
@@ -74,12 +75,8 @@ export default function (plop: NodePlopAPI): void {
         base: path.join(templatesPath, "wallets/rainbowkit/components/"),
         templateFiles: path.join(templatesPath, "wallets/rainbowkit/components/*.tsx.hbs"),
         skip: (data: PlopData): string | false => {
-          if (
-            data.templateType === "farcaster-miniapp" ||
-            data.templateType === "minipay" ||
-            data.templateType === "x402"
-          ) {
-            return "Skipping RainbowKit - This template uses its own wallet components";
+          if (ignoresWalletProvider(data.templateType)) {
+            return walletSkipReason("RainbowKit", data.templateType);
           }
           if (data.walletProvider !== "rainbowkit") {
             return "Skipping RainbowKit - different wallet provider selected";
@@ -126,11 +123,8 @@ export default function (plop: NodePlopAPI): void {
         base: path.join(templatesPath, "wallets/thirdweb/components/"),
         templateFiles: path.join(templatesPath, "wallets/thirdweb/components/*.tsx.hbs"),
         skip: (data: PlopData): string | false => {
-          if (
-            data.templateType === "farcaster-miniapp" ||
-            data.templateType === "x402"
-          ) {
-            return "Skipping Thirdweb - this template uses its own wallet components";
+          if (ignoresWalletProvider(data.templateType)) {
+            return walletSkipReason("Thirdweb", data.templateType);
           }
           if (data.walletProvider !== "thirdweb") {
             return "Skipping Thirdweb - different wallet provider selected";
@@ -146,8 +140,11 @@ export default function (plop: NodePlopAPI): void {
         base: path.join(templatesPath, "wallets/thirdweb/lib/"),
         templateFiles: path.join(templatesPath, "wallets/thirdweb/lib/*.ts.hbs"),
         skip: (data: PlopData): string | false => {
-          if (data.templateType === "farcaster-miniapp") {
-            return "Skipping Thirdweb lib - Farcaster Miniapp uses its own wallet components";
+          // Same guard as the components action above. It was narrower than
+          // that one, which was harmless only because walletProvider is forced
+          // to "none" for the templates it missed — a latent copy of #396.
+          if (ignoresWalletProvider(data.templateType)) {
+            return walletSkipReason("Thirdweb lib", data.templateType);
           }
           if (data.walletProvider !== "thirdweb") {
             return "Skipping Thirdweb lib - different wallet provider selected";

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -1,0 +1,51 @@
+/**
+ * Which templates cannot honour an explicit `--wallet-provider`, and why.
+ *
+ * This lived in four places before — the forcing in `create.ts`, two comments
+ * next to it, and the skip strings in `plopfile.ts` — and the copies had
+ * drifted apart: the strings claimed every affected template "uses its own
+ * wallet components", which is false for half of them, and `minipay` was
+ * missing from the forcing entirely (see below). One list, read by everything.
+ *
+ * The two reasons are different and the difference is user-facing:
+ *
+ * - `SHIPS_OWN_WALLET` writes its own connect button and provider, under the
+ *   *same filenames* the wallet templates use. Letting a wallet template write
+ *   too is not a preference clash, it is a collision: plop aborts the whole
+ *   run with "File already exists" and leaves a half-generated project.
+ *
+ * - `SHIPS_NO_WALLET` writes no wallet UI at all. Honouring the flag there
+ *   produced a navbar importing a component nothing writes (#396); with that
+ *   fixed it produces a project simply missing what was asked for.
+ */
+export const SHIPS_OWN_WALLET = ["farcaster-miniapp", "minipay"];
+export const SHIPS_NO_WALLET = ["ai-chat", "x402"];
+
+/** True when an explicit `--wallet-provider` cannot be applied to this template. */
+export function ignoresWalletProvider(templateType: string | undefined): boolean {
+  if (!templateType) return false;
+  return (
+    SHIPS_OWN_WALLET.includes(templateType) ||
+    SHIPS_NO_WALLET.includes(templateType)
+  );
+}
+
+/**
+ * Why this template ignores `--wallet-provider`, as a sentence fragment, so the
+ * CLI warning and the plop skip messages cannot drift apart again.
+ */
+export function walletOverrideReason(templateType: string): string {
+  return SHIPS_OWN_WALLET.includes(templateType)
+    ? `the ${templateType} template ships its own wallet components`
+    : `the ${templateType} template ships no wallet layer of its own`;
+}
+
+/**
+ * The reason shown when a wallet action is skipped, accurate for the template
+ * that caused it rather than one sentence covering both cases.
+ *
+ * `subject` names the action being skipped, e.g. "RainbowKit" or "Thirdweb lib".
+ */
+export function walletSkipReason(subject: string, templateType: string): string {
+  return `Skipping ${subject} - ${walletOverrideReason(templateType)}`;
+}

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -1,40 +1,95 @@
 /**
- * Which templates cannot honour an explicit `--wallet-provider`, and why.
+ * How each template relates to `--wallet-provider`.
  *
- * This lived in four places before — the forcing in `create.ts`, two comments
- * next to it, and the skip strings in `plopfile.ts` — and the copies had
- * drifted apart: the strings claimed every affected template "uses its own
- * wallet components", which is false for half of them, and `minipay` was
- * missing from the forcing entirely (see below). One list, read by everything.
+ * There are two different questions here, and the first version of this file
+ * answered them with one list — which broke minipay. They are:
  *
- * The two reasons are different and the difference is user-facing:
+ *   1. **What must `walletProvider` be set to?** (`forcedWalletProvider`)
+ *   2. **Which wallet-template files must not be written?** (`skipsWalletTemplateFiles`)
  *
- * - `SHIPS_OWN_WALLET` writes its own connect button and provider, under the
- *   *same filenames* the wallet templates use. Letting a wallet template write
- *   too is not a preference clash, it is a collision: plop aborts the whole
- *   run with "File already exists" and leaves a half-generated project.
+ * For farcaster-miniapp, x402 and ai-chat the answers coincide: nothing is
+ * written and the value is "none". For **minipay they do not**. minipay ships
+ * its own `connect-button.tsx` and `wallet-provider.tsx`, so the wallet
+ * templates must not write those files — but its components are *built on*
+ * RainbowKit (`wallet-provider.tsx` imports `RainbowKitProvider`,
+ * `WagmiProvider` and `QueryClientProvider`; `user-balance.tsx` uses wagmi
+ * hooks), and the base manifest gates `@rainbow-me/rainbowkit`, `wagmi`, `viem`
+ * and `@tanstack/react-query` on `walletProvider === "rainbowkit"`.
  *
- * - `SHIPS_NO_WALLET` writes no wallet UI at all. Honouring the flag there
- *   produced a navbar importing a component nothing writes (#396); with that
- *   fixed it produces a project simply missing what was asked for.
+ * Forcing minipay to "none" therefore produced a scaffold with its own wallet
+ * components and none of the packages they import. Caught in review on #461.
+ */
+
+/**
+ * Templates that require one specific provider, whatever the flag says.
+ *
+ * minipay is not "ignores the flag" — it *needs* rainbowkit. Forcing that value
+ * also resolves the collision this list was originally added for: the rainbowkit
+ * components action already skips on `templateType === "minipay"`, and both
+ * thirdweb actions skip on `walletProvider !== "thirdweb"`, so no two actions
+ * write the same filename.
+ */
+export const REQUIRES_WALLET: Record<string, string> = {
+  "minipay": "rainbowkit",
+};
+
+/**
+ * Templates that write their own connect button and wallet provider, under the
+ * same filenames the wallet templates use.
+ *
+ * Letting a wallet template write as well is not a preference clash, it is a
+ * collision: plop aborts the whole run with "File already exists" and leaves a
+ * half-generated project.
  */
 export const SHIPS_OWN_WALLET = ["farcaster-miniapp", "minipay"];
+
+/**
+ * Templates with no wallet UI at all.
+ *
+ * Honouring the flag here produced a navbar importing a component nothing
+ * writes (#396); with that fixed it produces a project simply missing what was
+ * asked for.
+ */
 export const SHIPS_NO_WALLET = ["ai-chat", "x402"];
 
-/** True when an explicit `--wallet-provider` cannot be applied to this template. */
-export function ignoresWalletProvider(templateType: string | undefined): boolean {
+/**
+ * The value `walletProvider` must take for this template, or `null` when the
+ * flag (or the default) is honoured as given.
+ */
+export function forcedWalletProvider(templateType: string | undefined): string | null {
+  if (!templateType) return null;
+  const required = REQUIRES_WALLET[templateType];
+  if (required !== undefined) return required;
+  if (SHIPS_OWN_WALLET.includes(templateType) || SHIPS_NO_WALLET.includes(templateType)) {
+    return "none";
+  }
+  return null;
+}
+
+/**
+ * True when the rainbowkit/thirdweb component actions must not write for this
+ * template — because it either ships those files itself or wants none.
+ *
+ * Deliberately NOT the same predicate as `forcedWalletProvider`: minipay is in
+ * here and still gets a real provider value.
+ */
+export function skipsWalletTemplateFiles(templateType: string | undefined): boolean {
   if (!templateType) return false;
   return (
-    SHIPS_OWN_WALLET.includes(templateType) ||
-    SHIPS_NO_WALLET.includes(templateType)
+    SHIPS_OWN_WALLET.includes(templateType) || SHIPS_NO_WALLET.includes(templateType)
   );
 }
 
 /**
- * Why this template ignores `--wallet-provider`, as a sentence fragment, so the
- * CLI warning and the plop skip messages cannot drift apart again.
+ * Why this template will not take the provider that was asked for, as a
+ * sentence fragment, so the CLI warning and the plop skip messages cannot drift
+ * apart again.
  */
 export function walletOverrideReason(templateType: string): string {
+  const required = REQUIRES_WALLET[templateType];
+  if (required !== undefined) {
+    return `the ${templateType} template ships its own ${required}-based wallet components`;
+  }
   return SHIPS_OWN_WALLET.includes(templateType)
     ? `the ${templateType} template ships its own wallet components`
     : `the ${templateType} template ships no wallet layer of its own`;


### PR DESCRIPTION
Closes #453. All three items from that issue, plus a crash found while verifying item 3 that belongs with them.

## 1. The flag is discarded without a word

`create app -t x402 --wallet-provider thirdweb` exited 0 and produced a project with no thirdweb in it. The forcing is right — the plop guards skip the wallet actions regardless, so honouring the flag would only write a navbar importing a component nothing generates (#396) — but nothing told the user their flag did nothing.

Now it warns, on stderr, naming the flag and the reason:

```
⚠️  Ignoring --wallet-provider thirdweb: the x402 template ships no wallet layer of its own.
```

`--wallet-provider none` stays quiet. That is what the forcing produces anyway, so it agrees rather than conflicts.

## 2. The skip message was false for half the templates it covered

`Skipping RainbowKit - This template uses its own wallet components` was shown for x402 too, which ships **none** — which is exactly why the flag cannot be honoured there. The one explanation a user got pointed at a wallet layer that does not exist.

The reason now depends on the template, and the list lives in `src/utils/templates.ts` rather than being restated at each guard. That drift is the whole bug: the same fact was written in four places (the forcing, two comments beside it, and the strings) and the copies disagreed.

## 3. The thirdweb lib guard did not match its components guard

Aligned, as the issue asks. Both now read the shared list.

## The part that was not in the issue: minipay

Checking item 3 turned up a live crash rather than a latent one. `minipay` was absent from the forcing, and it writes `connect-button.tsx` and `wallet-provider.tsx` — the same two filenames the thirdweb template writes. Nothing stopped both actions from running.

On `main` (`666f51a`):

```
$ create mp -t minipay --wallet-provider thirdweb --skip-install -y
Error: Template generation failed: File already exists
 -> apps/web/src/components/connect-button.tsx
$ echo $?
1
```

The project is left half on disk. Adding minipay to the shared list fixes it, and it is the same edit the other three items need, so separating it would mean touching these lines twice.

**Flagging the scope explicitly** in case you would rather I split it: the issue names farcaster-miniapp, ai-chat and x402, and this PR also changes behaviour for minipay.

## Verification

Generated from this branch, with a control run each time so a guard that suppresses everything would not pass:

| command | before | after |
|---|---|---|
| `-t minipay --wallet-provider thirdweb` | exit 1, half-written | exit 0, minipay's own three components, no `lib/client.ts`, warns |
| `-t x402 --wallet-provider thirdweb` | exit 0, silent | warns "ships no wallet layer of its own" |
| `-t basic --wallet-provider thirdweb` | thirdweb wired | unchanged — `lib/client.ts` present, silent |
| `-t x402 --wallet-provider none` | silent | silent |

Four regression tests added to `template-wiring.test.ts`, including the control. The helper moved from `execFileSync` to `spawnSync` because the diagnostic is on stderr and `execFileSync` only returns stdout. **26/26 pass**, `tsc` clean, `eslint` clean apart from one pre-existing warning in `scaffold-smoke.test.ts` that this branch does not touch.